### PR TITLE
chore: pin Bun package manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,6 @@
     "postcss": "^8.5.3",
     "tailwindcss": "^3.4.17",
     "typescript": "5.9.3"
-  }
+  },
+  "packageManager": "bun@1.3.12"
 }


### PR DESCRIPTION
## Summary

Adds `packageManager: bun@1.3.12` to the app manifest.

## Why

This app already builds/deploys with Bun — the Dockerfile uses `oven/bun` and `bun install --frozen-lockfile` — but `package.json` did not declare a package manager. Pinning it keeps local tooling and future CI on a consistent Bun version.

## Validation

- `bun install --frozen-lockfile` — OK
- `bun run lint` — exit 0 (warnings/infos only)
- `bun run build` — OK

## Impact

Metadata-only. No dependency, lockfile, runtime code, or deploy config changes.