### PR TITLE
feat(rust-first): land durable portfolio API differential harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,11 @@ concurrency:
 jobs:
   rust-api:
     name: Rust API + differential (ADR-168)
-    # Canonical Sylphx Platform JIT profile (legacy 4-label set matches 0 online runners)
-    runs-on: sylphx-linux-standard
+    # shtse8 personal repo: 0 repo self-hosted runners; SylphxAI org runners
+    # (sylphx-linux-standard) cannot pick up jobs outside the org. Legacy
+    # [self-hosted,sylphx,linux,standard] matched nothing. GitHub-hosted is
+    # the only runnable profile for this public personal repo's GHA jobs.
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,12 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Test api-rust
+      # Differential integration tests spawn `bun` (or require PORTFOLIO_ORACLE_JSON).
+      # Run them only via the harness after Bun is installed — avoids spawn ENOENT
+      # on plain `cargo test` when bun is not yet on PATH.
+      - name: Test api-rust (unit/contract; skip differential spawn path)
         working-directory: api-rust
-        run: cargo test
+        run: cargo test -- --skip differential_matches_ts_oracle
 
       - name: No TS backend authority (ADR-168 S3)
         run: bash scripts/check-no-ts-backend.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  merge_group:
+    types: [checks_requested]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rust-api:
+    name: Rust API + differential (ADR-168)
+    runs-on: [self-hosted, sylphx, linux, standard]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Test api-rust
+        working-directory: api-rust
+        run: cargo test
+
+      - name: No TS backend authority (ADR-168 S3)
+        run: bash scripts/check-no-ts-backend.sh
+
+      - name: Setup Bun (differential oracle)
+        uses: oven-sh/setup-bun@v2
+
+      - name: Differential parity (rej-010 portfolio backend caps)
+        run: bash scripts/run-portfolio-differential.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,8 @@ concurrency:
 jobs:
   rust-api:
     name: Rust API + differential (ADR-168)
-    runs-on: [self-hosted, sylphx, linux, standard]
+    # Canonical Sylphx Platform JIT profile (legacy 4-label set matches 0 online runners)
+    runs-on: sylphx-linux-standard
     steps:
       - uses: actions/checkout@v4
 

--- a/api-rust/Cargo.lock
+++ b/api-rust/Cargo.lock
@@ -92,6 +92,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,8 +141,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -143,6 +161,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -168,6 +196,16 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "displaydoc"
@@ -303,6 +341,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -614,6 +662,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "time",
  "tokio",
  "tokio-stream",
@@ -1107,6 +1156,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1457,6 +1517,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1502,6 +1568,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"

--- a/api-rust/Cargo.toml
+++ b/api-rust/Cargo.toml
@@ -6,11 +6,16 @@ rust-version = "1.75"
 description = "Rust drop-in authority for kylet.se live API (stats, terminal data, AI chat)"
 license = "MIT"
 
+[lib]
+name = "kylet_api_rust"
+path = "src/lib.rs"
+
 [[bin]]
 name = "kylet-api-rust"
 path = "src/main.rs"
 
 [dependencies]
+sha2 = "0.10"
 axum = { version = "0.8", features = ["json"] }
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }

--- a/api-rust/src/activity.rs
+++ b/api-rust/src/activity.rs
@@ -1,53 +1,21 @@
+use crate::contract::{
+    aggregate_activity_from_graphql, build_org_activity_graphql_block,
+    build_user_activity_graphql_block, normalize_activity_graphql_response, ActivityPayload,
+    GITHUB_OWNERS, WEEK_MS,
+};
 use reqwest::Client;
-use serde::Serialize;
 use std::env;
 use std::sync::Mutex;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-const ACTIVITY_TTL_MS: u64 = 90 * 1000;
-const DAY_MS: u64 = 86_400_000;
-const WEEK_MS: u64 = 7 * DAY_MS;
+const DEFAULT_ACTIVITY_TTL_MS: u64 = 90 * 1000;
 
-struct GithubOwner {
-    login: &'static str,
-    kind: &'static str,
-}
-
-const GITHUB_OWNERS: &[GithubOwner] = &[
-    GithubOwner {
-        login: "shtse8",
-        kind: "user",
-    },
-    GithubOwner {
-        login: "SylphxAI",
-        kind: "organization",
-    },
-    GithubOwner {
-        login: "Cubeage",
-        kind: "organization",
-    },
-    GithubOwner {
-        login: "EpiowAI",
-        kind: "organization",
-    },
-];
-
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct LastPush {
-    pub repo: String,
-    pub ago: String,
-}
-
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ActivityPayload {
-    pub commits_today: u64,
-    pub commits_week: u64,
-    pub commits_month: u64,
-    pub repos_active_today: u64,
-    pub last_push: Option<LastPush>,
-    pub updated_at: String,
+fn activity_ttl_ms() -> u64 {
+    env::var("ACTIVITY_TTL_MS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .filter(|&v| v > 0)
+        .unwrap_or(DEFAULT_ACTIVITY_TTL_MS)
 }
 
 static CACHE: std::sync::OnceLock<Mutex<Option<(u64, ActivityPayload)>>> =
@@ -71,161 +39,57 @@ fn client() -> Client {
         .unwrap_or_else(|_| Client::new())
 }
 
-async fn github_graphql(query: &str) -> Result<serde_json::Value, String> {
+fn graphql_url() -> String {
+    env::var("GITHUB_GRAPHQL_URL")
+        .unwrap_or_else(|_| "https://api.github.com/graphql".to_string())
+}
+
+fn github_token() -> Result<String, String> {
     let token = env::var("GITHUB_TOKEN").map_err(|_| "GITHUB_TOKEN not set".to_string())?;
+    if token.is_empty() {
+        return Err("GITHUB_TOKEN empty".to_string());
+    }
+    Ok(token)
+}
+
+pub async fn github_graphql(query: &str) -> Result<serde_json::Value, String> {
+    let token = github_token()?;
     let res = client()
-        .post("https://api.github.com/graphql")
+        .post(graphql_url())
         .header("authorization", format!("bearer {token}"))
         .header("content-type", "application/json")
         .header("user-agent", "kylet-api-rust")
         .json(&serde_json::json!({ "query": query }))
         .send()
         .await
-        .map_err(|e| e.to_string())?;
-    if !res.status().is_success() {
-        return Err(format!("github graphql {}", res.status()));
+        .map_err(|e| format!("github graphql transport: {e}"))?;
+    let status = res.status();
+    if !status.is_success() {
+        let body = res.text().await.unwrap_or_default();
+        return Err(format!(
+            "github graphql http {status}: {}",
+            body.chars().take(200).collect::<String>()
+        ));
     }
-    let body: serde_json::Value = res.json().await.map_err(|e| e.to_string())?;
+    let body: serde_json::Value = res
+        .json()
+        .await
+        .map_err(|e| format!("github graphql decode: {e}"))?;
     if let Some(errors) = body.get("errors") {
         return Err(format!(
-            "github graphql: {}",
-            errors.to_string().chars().take(200).collect::<String>()
+            "github graphql errors: {}",
+            errors.to_string().chars().take(300).collect::<String>()
         ));
     }
     body.get("data")
         .cloned()
-        .ok_or_else(|| "missing data".to_string())
-}
-
-fn format_ago(now: u64, when: &str) -> String {
-    let when_ms = chrono_like_parse(when);
-    let diff = now.saturating_sub(when_ms);
-    let mins = diff / 60_000;
-    let hrs = mins / 60;
-    let days = hrs / 24;
-    if days > 0 {
-        format!("{days}d ago")
-    } else if hrs > 0 {
-        format!("{hrs}h ago")
-    } else if mins > 0 {
-        format!("{mins}m ago")
-    } else {
-        "just now".to_string()
-    }
-}
-
-fn chrono_like_parse(iso: &str) -> u64 {
-    time::OffsetDateTime::parse(iso, &time::format_description::well_known::Rfc3339)
-        .ok()
-        .map(|dt| (dt.unix_timestamp_nanos() / 1_000_000) as u64)
-        .unwrap_or(0)
+        .ok_or_else(|| "github graphql missing data".to_string())
 }
 
 fn iso_now() -> String {
     time::OffsetDateTime::now_utc()
         .format(&time::format_description::well_known::Rfc3339)
         .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string())
-}
-
-async fn compute_activity() -> Result<ActivityPayload, String> {
-    let now = now_ms();
-    let week_start = iso_from_ms(now.saturating_sub(WEEK_MS));
-    let now_iso = iso_now();
-
-    let blocks: String = GITHUB_OWNERS
-        .iter()
-        .enumerate()
-        .map(|(i, o)| {
-            let entity = if o.kind == "organization" {
-                "organization"
-            } else {
-                "user"
-            };
-            format!(
-                "o{i}: {entity}(login: \"{}\") {{
-          contributionsCollection(from: \"{week_start}\", to: \"{now_iso}\") {{
-            totalCommitContributions
-            commitContributionsByRepository(maxRepositories: 20) {{
-              repository {{ nameWithOwner pushedAt }}
-              contributions {{ totalCount }}
-            }}
-          }}
-        }}",
-                o.login
-            )
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
-
-    let data = github_graphql(&format!("{{ {blocks} }}")).await?;
-
-    let mut commits_today = 0u64;
-    let mut commits_week = 0u64;
-    let mut repos_active_today = std::collections::HashSet::new();
-    let mut last_push: Option<(String, String)> = None;
-
-    for (i, _) in GITHUB_OWNERS.iter().enumerate() {
-        let cc = data
-            .get(format!("o{i}"))
-            .and_then(|v| v.get("contributionsCollection"));
-        let Some(cc) = cc else { continue };
-
-        commits_week += cc
-            .get("totalCommitContributions")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(0);
-
-        let by_repo = cc
-            .get("commitContributionsByRepository")
-            .and_then(|v| v.as_array());
-
-        if let Some(entries) = by_repo {
-            for entry in entries {
-                let repo = entry
-                    .get("repository")
-                    .and_then(|r| r.get("nameWithOwner"))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
-                let count = entry
-                    .get("contributions")
-                    .and_then(|c| c.get("totalCount"))
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0);
-                let pushed_at = entry
-                    .get("repository")
-                    .and_then(|r| r.get("pushedAt"))
-                    .and_then(|v| v.as_str());
-
-                if let Some(pushed_at) = pushed_at {
-                    let ts = chrono_like_parse(pushed_at);
-                    if now.saturating_sub(ts) < DAY_MS {
-                        repos_active_today.insert(repo.to_string());
-                        commits_today += count;
-                    }
-                    if last_push.as_ref().is_none_or(|(_, when)| ts > chrono_like_parse(when)) {
-                        last_push = Some((repo.to_string(), pushed_at.to_string()));
-                    }
-                }
-            }
-        }
-    }
-
-    let last_push_display = last_push.map(|(repo, when)| {
-        let short = repo.split('/').nth(1).unwrap_or(&repo).to_string();
-        LastPush {
-            repo: short,
-            ago: format_ago(now, &when),
-        }
-    });
-
-    Ok(ActivityPayload {
-        commits_today,
-        commits_week,
-        commits_month: commits_week.saturating_mul(4),
-        repos_active_today: repos_active_today.len() as u64,
-        last_push: last_push_display,
-        updated_at: iso_now(),
-    })
 }
 
 fn iso_from_ms(ms: u64) -> String {
@@ -239,18 +103,100 @@ fn iso_from_ms(ms: u64) -> String {
         .unwrap_or_else(|| "1970-01-01T00:00:00Z".to_string())
 }
 
+pub fn build_activity_graphql_query(week_start: &str, now_iso: &str) -> String {
+    let blocks: String = GITHUB_OWNERS
+        .iter()
+        .enumerate()
+        .map(|(i, (login, kind))| {
+            if *kind == "organization" {
+                build_org_activity_graphql_block(i, login, week_start)
+            } else {
+                build_user_activity_graphql_block(i, login, week_start, now_iso)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!("{{ {blocks} }}")
+}
+
+pub async fn compute_activity() -> Result<ActivityPayload, String> {
+    let now = now_ms();
+    let week_start = iso_from_ms(now.saturating_sub(WEEK_MS));
+    let now_iso = iso_now();
+    let query = build_activity_graphql_query(&week_start, &now_iso);
+    let data = github_graphql(&query).await?;
+    let normalized = normalize_activity_graphql_response(&data);
+    let owner_keys: Vec<String> = (0..GITHUB_OWNERS.len()).map(|i| format!("o{i}")).collect();
+    Ok(aggregate_activity_from_graphql(
+        &normalized,
+        &owner_keys,
+        now,
+        &iso_now(),
+    ))
+}
+
 pub async fn get_activity() -> Result<ActivityPayload, String> {
     let now = now_ms();
+    let stale = cache()
+        .lock()
+        .ok()
+        .and_then(|guard| guard.as_ref().map(|(_, data)| data.clone()));
+
     if let Ok(guard) = cache().lock() {
         if let Some((at, data)) = guard.as_ref() {
-            if now.saturating_sub(*at) < ACTIVITY_TTL_MS {
+            if now.saturating_sub(*at) < activity_ttl_ms() {
                 return Ok(data.clone());
             }
         }
     }
-    let data = compute_activity().await?;
-    if let Ok(mut guard) = cache().lock() {
-        *guard = Some((now, data.clone()));
+
+    match compute_activity().await {
+        Ok(data) => {
+            if let Ok(mut guard) = cache().lock() {
+                *guard = Some((now, data.clone()));
+            }
+            Ok(data)
+        }
+        Err(err) => {
+            if let Some(cached) = stale {
+                tracing::warn!(
+                    error = %err,
+                    upstream = "github_graphql",
+                    route = "/activity",
+                    "activity upstream failed; serving stale cache"
+                );
+                return Ok(cached);
+            }
+            Err(err)
+        }
     }
-    Ok(data)
+}
+
+#[doc(hidden)]
+pub fn reset_cache_for_tests() {
+    if let Ok(mut guard) = cache().lock() {
+        *guard = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_activity_graphql_query;
+
+    #[test]
+    fn activity_query_uses_user_contributions_for_users_only() {
+        let query = build_activity_graphql_query("2026-07-01T00:00:00Z", "2026-07-10T00:00:00Z");
+        assert!(query.contains("o0: user(login: \"shtse8\")"));
+        assert!(query.contains("contributionsCollection(from: \"2026-07-01T00:00:00Z\""));
+        assert!(!query.contains("organization(login: \"shtse8\")"));
+    }
+
+    #[test]
+    fn activity_query_uses_org_repositories_not_contributions_collection() {
+        let query = build_activity_graphql_query("2026-07-01T00:00:00Z", "2026-07-10T00:00:00Z");
+        assert!(query.contains("o1: organization(login: \"SylphxAI\")"));
+        assert!(query.contains("repositories(first: 50"));
+        let org_section = query.split("o1: organization").nth(1).expect("org section");
+        assert!(!org_section.contains("contributionsCollection"));
+    }
 }

--- a/api-rust/src/contract.rs
+++ b/api-rust/src/contract.rs
@@ -1,0 +1,399 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+pub const ALLOWED_ORIGINS: &[&str] = &[
+    "https://kylet.se",
+    "https://www.kylet.se",
+    "https://loud-slab-t9c6ai.sylphx.app",
+    "http://localhost:3000",
+];
+
+pub const DAY_MS: u64 = 86_400_000;
+pub const WEEK_MS: u64 = 7 * DAY_MS;
+
+pub const IP_WINDOW_MS: u64 = 3 * 60_000;
+pub const IP_MAX_IN_WINDOW: usize = 12;
+pub const IP_MAX_PER_DAY: usize = 60;
+pub const GLOBAL_MAX_PER_DAY: usize = 500;
+
+pub const GITHUB_OWNERS: &[(&str, &str)] = &[
+    ("shtse8", "user"),
+    ("SylphxAI", "organization"),
+    ("Cubeage", "organization"),
+    ("EpiowAI", "organization"),
+];
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct LastPush {
+    pub repo: String,
+    pub ago: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ActivityPayload {
+    pub commits_today: u64,
+    pub commits_week: u64,
+    pub commits_month: u64,
+    pub repos_active_today: u64,
+    pub last_push: Option<LastPush>,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LimitVerdict {
+    Ok,
+    TooFast,
+    DailyIp,
+    GlobalDaily,
+}
+
+impl LimitVerdict {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Ok => "ok",
+            Self::TooFast => "tooFast",
+            Self::DailyIp => "dailyIp",
+            Self::GlobalDaily => "globalDaily",
+        }
+    }
+}
+
+pub fn valid_pkg(pkg: &str) -> bool {
+    if pkg.len() > 80 {
+        return false;
+    }
+    let mut rest = pkg;
+    if let Some(stripped) = pkg.strip_prefix('@') {
+        let (scope, name) = stripped.split_once('/').unwrap_or(("", ""));
+        if scope.is_empty() || name.is_empty() {
+            return false;
+        }
+        rest = name;
+    }
+    !rest.is_empty()
+        && rest
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_alphanumeric())
+        && rest
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_')
+}
+
+pub fn allowed_origin(origin: Option<&str>) -> &'static str {
+    origin
+        .and_then(|o| ALLOWED_ORIGINS.iter().copied().find(|&allowed| allowed == o))
+        .unwrap_or("https://kylet.se")
+}
+
+pub fn cors_header_map(origin: Option<&str>) -> BTreeMap<String, String> {
+    let allowed = allowed_origin(origin);
+    BTreeMap::from([
+        (
+            "access-control-allow-origin".to_string(),
+            allowed.to_string(),
+        ),
+        (
+            "access-control-allow-methods".to_string(),
+            "GET, POST, OPTIONS".to_string(),
+        ),
+        (
+            "access-control-allow-headers".to_string(),
+            "content-type".to_string(),
+        ),
+        (
+            "access-control-max-age".to_string(),
+            "86400".to_string(),
+        ),
+        ("vary".to_string(), "origin".to_string()),
+    ])
+}
+
+pub fn client_ip(headers: &[(String, String)]) -> String {
+    let pick = |name: &str| -> Option<String> {
+        headers
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case(name))
+            .map(|(_, v)| v.clone())
+    };
+    let raw = pick("x-forwarded-for")
+        .and_then(|v| v.split(',').next().map(str::trim).map(str::to_string))
+        .or_else(|| pick("x-real-ip"))
+        .or_else(|| pick("x-envoy-external-address"))
+        .or_else(|| pick("cf-connecting-ip"))
+        .unwrap_or_else(|| "unknown".to_string());
+    raw.chars().take(45).collect()
+}
+
+pub fn rate_limit_constants() -> Value {
+    json!({
+        "ipWindowMs": IP_WINDOW_MS,
+        "ipMaxInWindow": IP_MAX_IN_WINDOW,
+        "ipMaxPerDay": IP_MAX_PER_DAY,
+        "globalMaxPerDay": GLOBAL_MAX_PER_DAY,
+    })
+}
+
+pub fn check_rate_limit_isolated(ip: &str, now: u64, state: &mut RateLimitState) -> LimitVerdict {
+    let day = (now / 86_400_000) as i64;
+    if state.global_day != day {
+        state.global_day = day;
+        state.global_count = 0;
+        state.ip_day.clear();
+        state.ip_hits.clear();
+    }
+    if state.global_count >= GLOBAL_MAX_PER_DAY {
+        return LimitVerdict::GlobalDaily;
+    }
+    if ip != "unknown" {
+        let day_count = state
+            .ip_day
+            .get(ip)
+            .copied()
+            .unwrap_or(0);
+        if day_count >= IP_MAX_PER_DAY {
+            return LimitVerdict::DailyIp;
+        }
+        let hits: Vec<u64> = state
+            .ip_hits
+            .get(ip)
+            .map(|h| {
+                h.iter()
+                    .copied()
+                    .filter(|t| now.saturating_sub(*t) < IP_WINDOW_MS)
+                    .collect()
+            })
+            .unwrap_or_default();
+        if hits.len() >= IP_MAX_IN_WINDOW {
+            return LimitVerdict::TooFast;
+        }
+        let mut new_hits = hits;
+        new_hits.push(now);
+        state.ip_hits.insert(ip.to_string(), new_hits);
+        state.ip_day.insert(ip.to_string(), day_count + 1);
+    }
+    state.global_count += 1;
+    LimitVerdict::Ok
+}
+
+#[derive(Debug, Default)]
+pub struct RateLimitState {
+    ip_hits: std::collections::HashMap<String, Vec<u64>>,
+    ip_day: std::collections::HashMap<String, usize>,
+    global_day: i64,
+    global_count: usize,
+}
+
+pub fn simulate_burst_verdicts(ip: &str, base: u64) -> (Vec<String>, String) {
+    let mut state = RateLimitState::default();
+    let mut verdicts = Vec::new();
+    for i in 0..=IP_MAX_IN_WINDOW {
+        let verdict = check_rate_limit_isolated(ip, base + i as u64, &mut state);
+        verdicts.push(verdict.as_str().to_string());
+    }
+    let final_verdict = verdicts.last().cloned().unwrap_or_else(|| "unknown".to_string());
+    (verdicts, final_verdict)
+}
+
+pub fn parse_iso_ms(iso: &str) -> u64 {
+    time::OffsetDateTime::parse(iso, &time::format_description::well_known::Rfc3339)
+        .ok()
+        .map(|dt| (dt.unix_timestamp_nanos() / 1_000_000) as u64)
+        .unwrap_or(0)
+}
+
+pub fn format_ago(now_ms: u64, when: &str) -> String {
+    let when_ms = parse_iso_ms(when);
+    let diff = now_ms.saturating_sub(when_ms);
+    let mins = diff / 60_000;
+    let hrs = mins / 60;
+    let days = hrs / 24;
+    if days > 0 {
+        format!("{days}d ago")
+    } else if hrs > 0 {
+        format!("{hrs}h ago")
+    } else if mins > 0 {
+        format!("{mins}m ago")
+    } else {
+        "just now".to_string()
+    }
+}
+
+pub fn build_user_activity_graphql_block(index: usize, login: &str, week_start: &str, now_iso: &str) -> String {
+    format!(
+        "o{index}: user(login: \"{login}\") {{
+          contributionsCollection(from: \"{week_start}\", to: \"{now_iso}\") {{
+            totalCommitContributions
+            commitContributionsByRepository(maxRepositories: 20) {{
+              repository {{ nameWithOwner pushedAt }}
+              contributions {{ totalCount }}
+            }}
+          }}
+        }}"
+    )
+}
+
+pub fn build_org_activity_graphql_block(index: usize, login: &str, week_start: &str) -> String {
+    format!(
+        "o{index}: organization(login: \"{login}\") {{
+          repositories(first: 50, orderBy: {{field: PUSHED_AT, direction: DESC}}) {{
+            nodes {{
+              nameWithOwner
+              pushedAt
+              defaultBranchRef {{
+                target {{
+                  ... on Commit {{
+                    history(since: \"{week_start}\") {{ totalCount }}
+                  }}
+                }}
+              }}
+            }}
+          }}
+        }}"
+    )
+}
+
+pub fn normalize_activity_graphql_response(data: &Value) -> Value {
+    let mut normalized = serde_json::Map::new();
+    let Some(obj) = data.as_object() else {
+        return data.clone();
+    };
+
+    for (key, value) in obj {
+        if let Some(repos) = value.get("repositories").and_then(|v| v.get("nodes")).and_then(Value::as_array)
+        {
+            let mut total = 0u64;
+            let mut by_repo = Vec::new();
+            for repo in repos {
+                let name = repo
+                    .get("nameWithOwner")
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                let pushed_at = repo.get("pushedAt").and_then(Value::as_str).unwrap_or("");
+                let count = repo
+                    .get("defaultBranchRef")
+                    .and_then(|v| v.get("target"))
+                    .and_then(|v| v.get("history"))
+                    .and_then(|v| v.get("totalCount"))
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0);
+                total += count;
+                by_repo.push(json!({
+                    "repository": { "nameWithOwner": name, "pushedAt": pushed_at },
+                    "contributions": { "totalCount": count },
+                }));
+            }
+            normalized.insert(
+                key.clone(),
+                json!({
+                    "contributionsCollection": {
+                        "totalCommitContributions": total,
+                        "commitContributionsByRepository": by_repo,
+                    }
+                }),
+            );
+        } else {
+            normalized.insert(key.clone(), value.clone());
+        }
+    }
+
+    Value::Object(normalized)
+}
+
+pub fn aggregate_activity_from_graphql(
+    graphql: &Value,
+    owner_keys: &[String],
+    now_ms: u64,
+    updated_at: &str,
+) -> ActivityPayload {
+    let mut commits_today = 0u64;
+    let mut commits_week = 0u64;
+    let mut repos_active_today = std::collections::HashSet::new();
+    let mut last_push: Option<(String, String)> = None;
+
+    for key in owner_keys {
+        let Some(cc) = graphql
+            .get(key)
+            .and_then(|v| v.get("contributionsCollection"))
+        else {
+            continue;
+        };
+
+        commits_week += cc
+            .get("totalCommitContributions")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+
+        if let Some(entries) = cc
+            .get("commitContributionsByRepository")
+            .and_then(Value::as_array)
+        {
+            for entry in entries {
+                let repo = entry
+                    .get("repository")
+                    .and_then(|r| r.get("nameWithOwner"))
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                let count = entry
+                    .get("contributions")
+                    .and_then(|c| c.get("totalCount"))
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0);
+                let pushed_at = entry
+                    .get("repository")
+                    .and_then(|r| r.get("pushedAt"))
+                    .and_then(Value::as_str);
+
+                if let Some(pushed_at) = pushed_at {
+                    let ts = parse_iso_ms(pushed_at);
+                    if now_ms.saturating_sub(ts) < DAY_MS {
+                        repos_active_today.insert(repo.to_string());
+                        commits_today += count;
+                    }
+                    if last_push
+                        .as_ref()
+                        .is_none_or(|(_, when)| ts > parse_iso_ms(when))
+                    {
+                        last_push = Some((repo.to_string(), pushed_at.to_string()));
+                    }
+                }
+            }
+        }
+    }
+
+    let last_push_display = last_push.map(|(repo, when)| LastPush {
+        repo: repo.split('/').nth(1).unwrap_or(&repo).to_string(),
+        ago: format_ago(now_ms, &when),
+    });
+
+    ActivityPayload {
+        commits_today,
+        commits_week,
+        commits_month: commits_week.saturating_mul(4),
+        repos_active_today: repos_active_today.len() as u64,
+        last_push: last_push_display,
+        updated_at: updated_at.to_string(),
+    }
+}
+
+pub fn proto_contract_summary(proto_path: &Path) -> Value {
+    let raw = fs::read_to_string(proto_path).unwrap_or_default();
+    let proto_hash = sha256_hex(&raw);
+    let rpc_count = raw.matches("rpc ").count();
+    json!({
+        "service": "PortfolioApiService",
+        "rpcCount": rpc_count,
+        "protoHash": proto_hash,
+    })
+}
+
+fn sha256_hex(content: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(content.as_bytes());
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}

--- a/api-rust/src/cors.rs
+++ b/api-rust/src/cors.rs
@@ -1,18 +1,5 @@
 use axum::http::{HeaderMap, HeaderValue, Method};
-
-
-const ALLOWED_ORIGINS: &[&str] = &[
-    "https://kylet.se",
-    "https://www.kylet.se",
-    "https://loud-slab-t9c6ai.sylphx.app",
-    "http://localhost:3000",
-];
-
-pub fn allowed_origin(origin: Option<&str>) -> &'static str {
-    origin
-        .and_then(|o| ALLOWED_ORIGINS.iter().copied().find(|&a| a == o))
-        .unwrap_or("https://kylet.se")
-}
+use kylet_api_rust::contract::allowed_origin;
 
 pub fn cors_headers(origin: Option<&str>) -> HeaderMap {
     let mut headers = HeaderMap::new();

--- a/api-rust/src/lib.rs
+++ b/api-rust/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod activity;
+pub mod contract;

--- a/api-rust/src/main.rs
+++ b/api-rust/src/main.rs
@@ -1,4 +1,3 @@
-mod activity;
 mod chat;
 mod cors;
 mod http_util;
@@ -135,12 +134,18 @@ async fn recent_handler(headers: HeaderMap, Query(q): Query<LimitQuery>) -> Resp
 
 async fn activity_handler(headers: HeaderMap) -> Response {
     let origin = origin_from_headers(&headers);
-    match activity::get_activity().await {
+    match kylet_api_rust::activity::get_activity().await {
         Ok(data) => json_with_cors(data, origin.as_deref()),
         Err(err) => {
-            tracing::error!("activity error: {err}");
-            json_with_cors(
-                json!({ "error": "activity data briefly unavailable" }),
+            tracing::error!(
+                error = %err,
+                upstream = "github_graphql",
+                route = "/activity",
+                "activity upstream failure"
+            );
+            error_json(
+                StatusCode::BAD_GATEWAY,
+                "activity data briefly unavailable",
                 origin.as_deref(),
             )
         }
@@ -150,7 +155,7 @@ async fn activity_handler(headers: HeaderMap) -> Response {
 async fn downloads_handler(headers: HeaderMap, Query(q): Query<PkgQuery>) -> Response {
     let origin = origin_from_headers(&headers);
     let pkg = q.pkg.unwrap_or_default();
-    let valid = regex_pkg(&pkg);
+    let valid = kylet_api_rust::contract::valid_pkg(&pkg);
     let series = if valid {
         tools::npm_range(&pkg).await
     } else {
@@ -161,35 +166,6 @@ async fn downloads_handler(headers: HeaderMap, Query(q): Query<PkgQuery>) -> Res
         json!({ "pkg": pkg, "series": series, "total": total, "updatedAt": iso_now() }),
         origin.as_deref(),
     )
-}
-
-fn regex_pkg(pkg: &str) -> bool {
-    if pkg.len() > 80 {
-        return false;
-    }
-    regex_simple(pkg)
-}
-
-fn regex_simple(pkg: &str) -> bool {
-    let mut chars = pkg.chars();
-    if pkg.starts_with('@') {
-        let scope: String = chars.by_ref().take_while(|c| *c != '/').collect();
-        if !scope.starts_with('@') || scope.len() < 2 {
-            return false;
-        }
-        if chars.next() != Some('/') {
-            return false;
-        }
-    }
-    let name: String = chars.collect();
-    !name.is_empty()
-        && name
-            .chars()
-            .next()
-            .is_some_and(|c| c.is_ascii_alphanumeric())
-        && name
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_')
 }
 
 async fn chat_handler(headers: HeaderMap, Json(body): Json<chat::ChatRequest>) -> Response {

--- a/api-rust/src/rate_limit.rs
+++ b/api-rust/src/rate_limit.rs
@@ -1,11 +1,7 @@
-use std::collections::HashMap;
+use kylet_api_rust::contract::{
+    client_ip as contract_client_ip, check_rate_limit_isolated, RateLimitState,
+};
 use std::sync::Mutex;
-
-const IP_WINDOW_MS: u64 = 3 * 60_000;
-const IP_MAX_IN_WINDOW: usize = 12;
-const IP_MAX_PER_DAY: usize = 60;
-const GLOBAL_MAX_PER_DAY: usize = 500;
-const MAP_CAP: usize = 50_000;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum LimitVerdict {
@@ -15,109 +11,38 @@ pub enum LimitVerdict {
     GlobalDaily,
 }
 
-static STATE: std::sync::OnceLock<Mutex<RateState>> = std::sync::OnceLock::new();
-
-struct RateState {
-    ip_hits: HashMap<String, Vec<u64>>,
-    ip_day: HashMap<String, DayCount>,
-    global_day: DayCount,
-    last_prune: u64,
+impl From<kylet_api_rust::contract::LimitVerdict> for LimitVerdict {
+    fn from(value: kylet_api_rust::contract::LimitVerdict) -> Self {
+        match value {
+            kylet_api_rust::contract::LimitVerdict::Ok => Self::Ok,
+            kylet_api_rust::contract::LimitVerdict::TooFast => Self::TooFast,
+            kylet_api_rust::contract::LimitVerdict::DailyIp => Self::DailyIp,
+            kylet_api_rust::contract::LimitVerdict::GlobalDaily => Self::GlobalDaily,
+        }
+    }
 }
 
-struct DayCount {
-    day: i64,
-    n: usize,
-}
+static STATE: std::sync::OnceLock<Mutex<RateLimitState>> = std::sync::OnceLock::new();
 
-fn state() -> &'static Mutex<RateState> {
-    STATE.get_or_init(|| {
-        Mutex::new(RateState {
-            ip_hits: HashMap::new(),
-            ip_day: HashMap::new(),
-            global_day: DayCount { day: -1, n: 0 },
-            last_prune: 0,
-        })
-    })
-}
-
-fn day_number(now: u64) -> i64 {
-    (now / 86_400_000) as i64
+fn state() -> &'static Mutex<RateLimitState> {
+    STATE.get_or_init(|| Mutex::new(RateLimitState::default()))
 }
 
 pub fn client_ip(headers: &[(String, String)]) -> String {
-    let pick = |name: &str| -> Option<String> {
-        headers
-            .iter()
-            .find(|(k, _)| k.eq_ignore_ascii_case(name))
-            .map(|(_, v)| v.clone())
-    };
-    let raw = pick("x-forwarded-for")
-        .and_then(|v| v.split(',').next().map(str::trim).map(str::to_string))
-        .or_else(|| pick("x-real-ip"))
-        .or_else(|| pick("x-envoy-external-address"))
-        .or_else(|| pick("cf-connecting-ip"))
-        .unwrap_or_else(|| "unknown".to_string());
-    raw.chars().take(45).collect()
+    contract_client_ip(headers)
 }
 
 pub fn check_rate_limit(ip: &str, now: u64) -> LimitVerdict {
     let Ok(mut guard) = state().lock() else {
         return LimitVerdict::GlobalDaily;
     };
-    maybe_prune(&mut guard, now);
-    let day = day_number(now);
-    if guard.global_day.day != day {
-        guard.global_day = DayCount { day, n: 0 };
-    }
-    if guard.global_day.n >= GLOBAL_MAX_PER_DAY {
-        return LimitVerdict::GlobalDaily;
-    }
-    if ip != "unknown" && (guard.ip_day.contains_key(ip) || guard.ip_day.len() < MAP_CAP) {
-        let day_count = guard
-            .ip_day
-            .get(ip)
-            .filter(|d| d.day == day)
-            .map(|d| d.n)
-            .unwrap_or(0);
-        if day_count >= IP_MAX_PER_DAY {
-            return LimitVerdict::DailyIp;
-        }
-        let hits: Vec<u64> = guard
-            .ip_hits
-            .get(ip)
-            .map(|h| h.iter().copied().filter(|t| now.saturating_sub(*t) < IP_WINDOW_MS).collect())
-            .unwrap_or_default();
-        if hits.len() >= IP_MAX_IN_WINDOW {
-            return LimitVerdict::TooFast;
-        }
-        let mut new_hits = hits;
-        new_hits.push(now);
-        guard.ip_hits.insert(ip.to_string(), new_hits);
-        guard.ip_day.insert(ip.to_string(), DayCount {
-            day,
-            n: day_count + 1,
-        });
-    }
-    guard.global_day.n += 1;
-    LimitVerdict::Ok
-}
-
-fn maybe_prune(guard: &mut RateState, now: u64) {
-    if now.saturating_sub(guard.last_prune) < 10 * 60_000 {
-        return;
-    }
-    guard.last_prune = now;
-    let day = day_number(now);
-    guard.ip_hits.retain(|_, hits| {
-        hits.retain(|t| now.saturating_sub(*t) < IP_WINDOW_MS);
-        !hits.is_empty()
-    });
-    guard.ip_day.retain(|_, d| d.day == day);
+    check_rate_limit_isolated(ip, now, &mut guard).into()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use kylet_api_rust::contract::IP_MAX_IN_WINDOW;
 
     #[test]
     fn rate_limit_blocks_burst() {

--- a/api-rust/tests/parity.rs
+++ b/api-rust/tests/parity.rs
@@ -1,31 +1,11 @@
+use kylet_api_rust::contract::valid_pkg;
+
 #[test]
 fn pkg_validation_matches_bun_rules() {
     assert!(valid_pkg("@sylphx/pdf-reader-mcp"));
     assert!(valid_pkg("lodash"));
     assert!(!valid_pkg("not valid spaces"));
     assert!(!valid_pkg(""));
-}
-
-fn valid_pkg(pkg: &str) -> bool {
-    if pkg.len() > 80 {
-        return false;
-    }
-    let mut rest = pkg;
-    if let Some(stripped) = pkg.strip_prefix('@') {
-        let (scope, name) = stripped.split_once('/').unwrap_or(("", ""));
-        if scope.is_empty() || name.is_empty() {
-            return false;
-        }
-        rest = name;
-    }
-    !rest.is_empty()
-        && rest
-            .chars()
-            .next()
-            .is_some_and(|c| c.is_ascii_alphanumeric())
-        && rest
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_')
 }
 
 #[test]

--- a/api-rust/tests/portfolio_differential.rs
+++ b/api-rust/tests/portfolio_differential.rs
@@ -1,0 +1,220 @@
+//! TRUE differential parity: TS contract oracle vs native Rust contract SSOT.
+//!
+//! Fail-closed — no SKIP-as-pass. Oracle subprocess must succeed before comparison.
+//! Bounded slice entrypoints (rej-010):
+//! - health, pkgValidation, cors, clientIp, rateLimitConstants, activity, proto-contract
+//! See scripts/run-portfolio-differential.sh
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+use kylet_api_rust::contract::{
+    aggregate_activity_from_graphql, allowed_origin, client_ip, cors_header_map,
+    proto_contract_summary, rate_limit_constants, simulate_burst_verdicts, valid_pkg,
+};
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+#[derive(Debug, Deserialize)]
+struct OracleCase {
+    id: String,
+    slice: String,
+    domain: String,
+    input: Value,
+    output: Value,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OracleCorpus {
+    corpus_version: u32,
+    fixture_corpus_hash: String,
+    cases: Vec<OracleCase>,
+}
+
+fn load_oracle_corpus() -> OracleCorpus {
+    if let Ok(path) = std::env::var("PORTFOLIO_ORACLE_JSON") {
+        let raw = fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("read oracle artifact {path}: {error}"));
+        return serde_json::from_str(&raw).expect("oracle artifact must be valid JSON");
+    }
+
+    let script = repo_root().join("scripts/differential/portfolio-api-oracle.ts");
+    let output = Command::new("bun")
+        .arg("run")
+        .arg(&script)
+        .current_dir(repo_root())
+        .output()
+        .unwrap_or_else(|error| panic!("spawn TS oracle at {}: {error}", script.display()));
+
+    assert!(
+        output.status.success(),
+        "TS oracle failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    serde_json::from_slice(&output.stdout).expect("oracle output must be valid JSON")
+}
+
+fn evaluate_rust(case: &OracleCase) -> Value {
+    match case.domain.as_str() {
+        "healthz" => json!({ "status": "ok" }),
+        "validPkg" => json!(valid_pkg(
+            case.input
+                .get("pkg")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+        )),
+        "allowedOrigin" => {
+            let origin = case.input.get("origin").and_then(Value::as_str);
+            json!(allowed_origin(origin))
+        }
+        "corsHeaders" => {
+            let origin = case.input.get("origin").and_then(Value::as_str);
+            json!(cors_header_map(origin))
+        }
+        "clientIp" => {
+            let headers: Vec<(String, String)> = case
+                .input
+                .get("headers")
+                .and_then(Value::as_array)
+                .map(|rows| {
+                    rows.iter()
+                        .filter_map(|row| {
+                            let pair = row.as_array()?;
+                            Some((
+                                pair.first()?.as_str()?.to_string(),
+                                pair.get(1)?.as_str()?.to_string(),
+                            ))
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            json!(client_ip(&headers))
+        }
+        "constants" => rate_limit_constants(),
+        "burst" => {
+            let ip = case.input.get("ip").and_then(Value::as_str).unwrap_or("");
+            let base = case.input.get("base").and_then(Value::as_u64).unwrap_or(0);
+            let (verdicts, final_verdict) = simulate_burst_verdicts(ip, base);
+            json!({ "verdicts": verdicts, "final": final_verdict })
+        }
+        "aggregate" => {
+            let graphql = case.input.get("graphql").cloned().unwrap_or(json!({}));
+            let owner_keys: Vec<String> = case
+                .input
+                .get("ownerKeys")
+                .and_then(Value::as_array)
+                .map(|keys| {
+                    keys.iter()
+                        .filter_map(Value::as_str)
+                        .map(str::to_string)
+                        .collect()
+                })
+                .unwrap_or_default();
+            let now_ms = case.input.get("nowMs").and_then(Value::as_u64).unwrap_or(0);
+            let updated_at = case
+                .input
+                .get("updatedAt")
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            let payload =
+                aggregate_activity_from_graphql(&graphql, &owner_keys, now_ms, updated_at);
+            serde_json::to_value(payload).expect("activity payload json")
+        }
+        "service" => {
+            let rel = case.input.get("path").and_then(Value::as_str).unwrap_or("");
+            proto_contract_summary(&repo_root().join(rel))
+        }
+        other => panic!("unknown oracle domain: {other}"),
+    }
+}
+
+fn run_slice_cases(corpus: &OracleCorpus, slice: &str) {
+    for case in corpus.cases.iter().filter(|c| c.slice == slice) {
+        let actual = evaluate_rust(case);
+        assert_eq!(
+            actual, case.output,
+            "case {} ({}) mismatch",
+            case.id, case.domain
+        );
+    }
+}
+
+fn run_all_cases(corpus: &OracleCorpus) {
+    for case in &corpus.cases {
+        let actual = evaluate_rust(case);
+        assert_eq!(
+            actual, case.output,
+            "case {} ({}) mismatch",
+            case.id, case.domain
+        );
+    }
+}
+
+#[test]
+fn health_differential_matches_ts_oracle() {
+    let corpus = load_oracle_corpus();
+    run_slice_cases(&corpus, "health");
+}
+
+#[test]
+fn pkg_validation_differential_matches_ts_oracle() {
+    let corpus = load_oracle_corpus();
+    run_slice_cases(&corpus, "pkgValidation");
+}
+
+#[test]
+fn cors_differential_matches_ts_oracle() {
+    let corpus = load_oracle_corpus();
+    run_slice_cases(&corpus, "cors");
+}
+
+#[test]
+fn client_ip_differential_matches_ts_oracle() {
+    let corpus = load_oracle_corpus();
+    run_slice_cases(&corpus, "clientIp");
+}
+
+#[test]
+fn rate_limit_constants_differential_matches_ts_oracle() {
+    let corpus = load_oracle_corpus();
+    run_slice_cases(&corpus, "rateLimitConstants");
+}
+
+#[test]
+fn activity_differential_matches_ts_oracle() {
+    let corpus = load_oracle_corpus();
+    run_slice_cases(&corpus, "activity");
+}
+
+#[test]
+fn proto_contract_differential_matches_ts_oracle() {
+    let corpus = load_oracle_corpus();
+    run_slice_cases(&corpus, "proto-contract");
+}
+
+#[test]
+fn portfolio_differential_matches_ts_oracle() {
+    let corpus = load_oracle_corpus();
+    run_all_cases(&corpus);
+}
+
+#[test]
+fn cors_headers_match_contract() {
+    let headers = cors_header_map(Some("https://kylet.se"));
+    assert_eq!(
+        headers.get("access-control-allow-origin").map(String::as_str),
+        Some("https://kylet.se")
+    );
+    assert_eq!(
+        headers.get("access-control-allow-methods").map(String::as_str),
+        Some("GET, POST, OPTIONS")
+    );
+}

--- a/api-rust/tests/portfolio_differential.rs
+++ b/api-rust/tests/portfolio_differential.rs
@@ -44,13 +44,29 @@ fn load_oracle_corpus() -> OracleCorpus {
         return serde_json::from_str(&raw).expect("oracle artifact must be valid JSON");
     }
 
-    let script = repo_root().join("scripts/differential/portfolio-api-oracle.ts");
+    // Prefer pre-materialized oracle (harness sets PORTFOLIO_ORACLE_JSON). Fallback:
+    // spawn bun on the workspace-relative oracle script under repo root.
+    let root = repo_root();
+    let script = root.join("scripts/differential/portfolio-api-oracle.ts");
+    assert!(
+        script.is_file(),
+        "TS oracle missing at {} (repo_root={}). Set PORTFOLIO_ORACLE_JSON or ensure scripts/differential/portfolio-api-oracle.ts is present.",
+        script.display(),
+        root.display()
+    );
+
     let output = Command::new("bun")
         .arg("run")
         .arg(&script)
-        .current_dir(repo_root())
+        .current_dir(&root)
         .output()
-        .unwrap_or_else(|error| panic!("spawn TS oracle at {}: {error}", script.display()));
+        .unwrap_or_else(|error| {
+            panic!(
+                "spawn bun for TS oracle failed (is bun on PATH?): bun run {} (cwd={}): {error}",
+                script.display(),
+                root.display()
+            )
+        });
 
     assert!(
         output.status.success(),

--- a/docs/specs/portfolio-api-parity-slice.json
+++ b/docs/specs/portfolio-api-parity-slice.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": 1,
+  "repo": "shtse8/portfolio-website",
+  "slice": "portfolio-api-backend-caps",
+  "harness": "scripts/run-portfolio-differential.sh",
+  "oracle": "scripts/differential/portfolio-api-oracle.ts",
+  "behaviorSpec": "scripts/differential/fixtures/portfolio-api-corpus.json",
+  "differentialTest": "api-rust/tests/portfolio_differential.rs",
+  "contractSsot": "api-rust/src/contract.rs",
+  "boundedSlices": {
+    "health": "api-rust/tests/portfolio_differential.rs#health_differential_matches_ts_oracle",
+    "pkgValidation": "api-rust/tests/portfolio_differential.rs#pkg_validation_differential_matches_ts_oracle",
+    "cors": "api-rust/tests/portfolio_differential.rs#cors_differential_matches_ts_oracle",
+    "clientIp": "api-rust/tests/portfolio_differential.rs#client_ip_differential_matches_ts_oracle",
+    "rateLimitConstants": "api-rust/tests/portfolio_differential.rs#rate_limit_constants_differential_matches_ts_oracle",
+    "activity": "api-rust/tests/portfolio_differential.rs#activity_differential_matches_ts_oracle",
+    "proto-contract": "api-rust/tests/portfolio_differential.rs#proto_contract_differential_matches_ts_oracle"
+  },
+  "capabilities": [
+    "api-health-ready",
+    "api-terminal-tools",
+    "api-cors-rate-limit",
+    "api-activity-feed",
+    "proto-portfolio-contract"
+  ],
+  "notes": "Pure-policy differential for deleted Bun api/ semantics vs api-rust contract SSOT. Live upstream stats/chat slices deferred to api-smoke prod probes."
+}

--- a/scripts/check-no-ts-backend.sh
+++ b/scripts/check-no-ts-backend.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# ADR-168 S3 gate: Bun api/ backend authority must remain deleted; api-rust is sole API SSOT.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+violations=0
+
+report_violation() {
+  echo "VIOLATION: $*"
+  violations=$((violations + 1))
+}
+
+if [[ -d "${ROOT}/api" ]]; then
+  report_violation "api/ directory must remain deleted (Bun backend retired)"
+fi
+
+if [[ ! -d "${ROOT}/api-rust" ]]; then
+  report_violation "api-rust/ authority tree missing"
+fi
+
+if [[ ! -f "${ROOT}/api-rust/src/main.rs" ]]; then
+  report_violation "api-rust/src/main.rs missing"
+fi
+
+if [[ -f "${ROOT}/package.json" ]] && grep -qE '"api/' "${ROOT}/package.json"; then
+  report_violation "package.json must not reference deleted api/ scripts"
+fi
+
+if [[ "${violations}" -gt 0 ]]; then
+  echo ""
+  echo "FAIL: ${violations} TS backend authority violation(s)."
+  exit 1
+fi
+
+echo "check-no-ts-backend: PASS — api/ absent; api-rust authority present"

--- a/scripts/differential/fixtures/portfolio-api-corpus.json
+++ b/scripts/differential/fixtures/portfolio-api-corpus.json
@@ -1,0 +1,225 @@
+{
+  "corpusVersion": 1,
+  "cases": [
+    {
+      "id": "health-healthz",
+      "slice": "health",
+      "domain": "healthz",
+      "input": { "path": "/healthz" }
+    },
+    {
+      "id": "pkg-scoped",
+      "slice": "pkgValidation",
+      "domain": "validPkg",
+      "input": { "pkg": "@sylphx/pdf-reader-mcp" }
+    },
+    {
+      "id": "pkg-unscoped",
+      "slice": "pkgValidation",
+      "domain": "validPkg",
+      "input": { "pkg": "lodash" }
+    },
+    {
+      "id": "pkg-invalid-spaces",
+      "slice": "pkgValidation",
+      "domain": "validPkg",
+      "input": { "pkg": "not valid spaces" }
+    },
+    {
+      "id": "pkg-empty",
+      "slice": "pkgValidation",
+      "domain": "validPkg",
+      "input": { "pkg": "" }
+    },
+    {
+      "id": "pkg-too-long",
+      "slice": "pkgValidation",
+      "domain": "validPkg",
+      "input": {
+        "pkg": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      }
+    },
+    {
+      "id": "cors-kylet",
+      "slice": "cors",
+      "domain": "allowedOrigin",
+      "input": { "origin": "https://kylet.se" }
+    },
+    {
+      "id": "cors-www",
+      "slice": "cors",
+      "domain": "allowedOrigin",
+      "input": { "origin": "https://www.kylet.se" }
+    },
+    {
+      "id": "cors-localhost",
+      "slice": "cors",
+      "domain": "allowedOrigin",
+      "input": { "origin": "http://localhost:3000" }
+    },
+    {
+      "id": "cors-unknown-default",
+      "slice": "cors",
+      "domain": "allowedOrigin",
+      "input": { "origin": "https://evil.example" }
+    },
+    {
+      "id": "cors-headers-kylet",
+      "slice": "cors",
+      "domain": "corsHeaders",
+      "input": { "origin": "https://kylet.se" }
+    },
+    {
+      "id": "ip-xff",
+      "slice": "clientIp",
+      "domain": "clientIp",
+      "input": { "headers": [["x-forwarded-for", "203.0.113.1, 198.51.100.2"]] }
+    },
+    {
+      "id": "ip-real",
+      "slice": "clientIp",
+      "domain": "clientIp",
+      "input": { "headers": [["x-real-ip", "203.0.113.9"]] }
+    },
+    {
+      "id": "ip-cf",
+      "slice": "clientIp",
+      "domain": "clientIp",
+      "input": { "headers": [["cf-connecting-ip", "203.0.113.7"]] }
+    },
+    {
+      "id": "ip-unknown",
+      "slice": "clientIp",
+      "domain": "clientIp",
+      "input": { "headers": [] }
+    },
+    {
+      "id": "rate-constants",
+      "slice": "rateLimitConstants",
+      "domain": "constants",
+      "input": {}
+    },
+    {
+      "id": "rate-burst-block",
+      "slice": "rateLimitConstants",
+      "domain": "burst",
+      "input": { "ip": "203.0.113.1", "base": 1700000000000 }
+    },
+    {
+      "id": "activity-activity-multi-owner",
+      "slice": "activity",
+      "domain": "aggregate",
+      "input": {
+        "graphql": {
+          "o0": {
+            "contributionsCollection": {
+              "totalCommitContributions": 5,
+              "commitContributionsByRepository": [
+                {
+                  "repository": {
+                    "nameWithOwner": "shtse8/portfolio-website",
+                    "pushedAt": "2023-11-14T20:00:00Z"
+                  },
+                  "contributions": { "totalCount": 3 }
+                }
+              ]
+            }
+          },
+          "o1": {
+            "contributionsCollection": {
+              "totalCommitContributions": 7,
+              "commitContributionsByRepository": [
+                {
+                  "repository": {
+                    "nameWithOwner": "SylphxAI/gateway",
+                    "pushedAt": "2023-11-14T21:00:00Z"
+                  },
+                  "contributions": { "totalCount": 2 }
+                }
+              ]
+            }
+          }
+        },
+        "nowMs": 1700000000000,
+        "updatedAt": "2023-11-14T22:13:20Z",
+        "ownerKeys": ["o0", "o1"]
+      }
+    },
+    {
+      "id": "activity-activity-stale-push",
+      "slice": "activity",
+      "domain": "aggregate",
+      "input": {
+        "graphql": {
+          "o0": {
+            "contributionsCollection": {
+              "totalCommitContributions": 2,
+              "commitContributionsByRepository": [
+                {
+                  "repository": {
+                    "nameWithOwner": "shtse8/old-repo",
+                    "pushedAt": "2023-11-01T10:00:00Z"
+                  },
+                  "contributions": { "totalCount": 2 }
+                }
+              ]
+            }
+          }
+        },
+        "nowMs": 1700000000000,
+        "updatedAt": "2023-11-14T22:13:20Z",
+        "ownerKeys": ["o0"]
+      }
+    },
+    {
+      "id": "activity-activity-empty-collection",
+      "slice": "activity",
+      "domain": "aggregate",
+      "input": {
+        "graphql": {
+          "o0": {
+            "contributionsCollection": {
+              "totalCommitContributions": 0,
+              "commitContributionsByRepository": []
+            }
+          }
+        },
+        "nowMs": 1700000000000,
+        "updatedAt": "2023-11-14T22:13:20Z",
+        "ownerKeys": ["o0"]
+      }
+    },
+    {
+      "id": "activity-activity-just-now",
+      "slice": "activity",
+      "domain": "aggregate",
+      "input": {
+        "graphql": {
+          "o0": {
+            "contributionsCollection": {
+              "totalCommitContributions": 1,
+              "commitContributionsByRepository": [
+                {
+                  "repository": {
+                    "nameWithOwner": "shtse8/fresh",
+                    "pushedAt": "2023-11-14T22:12:00Z"
+                  },
+                  "contributions": { "totalCount": 1 }
+                }
+              ]
+            }
+          }
+        },
+        "nowMs": 1700000000000,
+        "updatedAt": "2023-11-14T22:13:20Z",
+        "ownerKeys": ["o0"]
+      }
+    },
+    {
+      "id": "proto-service-present",
+      "slice": "proto-contract",
+      "domain": "service",
+      "input": { "path": "proto/portfolio/v1/api.proto" }
+    }
+  ]
+}

--- a/scripts/differential/portfolio-api-oracle.ts
+++ b/scripts/differential/portfolio-api-oracle.ts
@@ -1,0 +1,286 @@
+#!/usr/bin/env bun
+/**
+ * TS oracle for portfolio API differential parity (rej-010).
+ * Encodes deleted Bun api/ north-star semantics (ADR-168) for contract comparison.
+ */
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '../..');
+const CORPUS_PATH = join(__dirname, 'fixtures/portfolio-api-corpus.json');
+
+const ALLOWED_ORIGINS = [
+  'https://kylet.se',
+  'https://www.kylet.se',
+  'https://loud-slab-t9c6ai.sylphx.app',
+  'http://localhost:3000',
+] as const;
+
+const DAY_MS = 86_400_000;
+const IP_WINDOW_MS = 3 * 60_000;
+const IP_MAX_IN_WINDOW = 12;
+const IP_MAX_PER_DAY = 60;
+const GLOBAL_MAX_PER_DAY = 500;
+
+type Json = null | boolean | number | string | Json[] | { [key: string]: Json };
+
+interface CorpusCase {
+  readonly id: string;
+  readonly slice: string;
+  readonly domain: string;
+  readonly input: Record<string, Json>;
+}
+
+interface CorpusManifest {
+  readonly corpusVersion: number;
+  readonly cases: readonly CorpusCase[];
+}
+
+interface OracleCase extends CorpusCase {
+  readonly output: Json;
+}
+
+function sha256Hex(content: string): string {
+  return createHash('sha256').update(content).digest('hex');
+}
+
+function validPkg(pkg: string): boolean {
+  if (pkg.length > 80) return false;
+  let rest = pkg;
+  if (pkg.startsWith('@')) {
+    const stripped = pkg.slice(1);
+    const slash = stripped.indexOf('/');
+    const scope = slash === -1 ? stripped : stripped.slice(0, slash);
+    const name = slash === -1 ? '' : stripped.slice(slash + 1);
+    if (!scope || !name) return false;
+    rest = name;
+  }
+  if (!rest) return false;
+  const first = rest.charCodeAt(0);
+  if (!((first >= 48 && first <= 57) || (first >= 65 && first <= 90) || (first >= 97 && first <= 122))) {
+    return false;
+  }
+  return [...rest].every((ch) => /[A-Za-z0-9._-]/.test(ch));
+}
+
+function allowedOrigin(origin: string | undefined): string {
+  if (origin && ALLOWED_ORIGINS.includes(origin as (typeof ALLOWED_ORIGINS)[number])) {
+    return origin;
+  }
+  return 'https://kylet.se';
+}
+
+function corsHeaders(origin: string | undefined): Record<string, string> {
+  const allowed = allowedOrigin(origin);
+  return {
+    'access-control-allow-origin': allowed,
+    'access-control-allow-methods': 'GET, POST, OPTIONS',
+    'access-control-allow-headers': 'content-type',
+    'access-control-max-age': '86400',
+    vary: 'origin',
+  };
+}
+
+function clientIp(headers: [string, string][]): string {
+  const pick = (name: string): string | undefined => {
+    const hit = headers.find(([key]) => key.toLowerCase() === name.toLowerCase());
+    return hit?.[1];
+  };
+  const raw =
+    pick('x-forwarded-for')
+      ?.split(',')[0]
+      ?.trim() ??
+    pick('x-real-ip') ??
+    pick('x-envoy-external-address') ??
+    pick('cf-connecting-ip') ??
+    'unknown';
+  return raw.slice(0, 45);
+}
+
+function parseIsoMs(iso: string): number {
+  const parsed = Date.parse(iso);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function formatAgo(nowMs: number, when: string): string {
+  const diff = Math.max(0, nowMs - parseIsoMs(when));
+  const mins = Math.floor(diff / 60_000);
+  const hrs = Math.floor(mins / 60);
+  const days = Math.floor(hrs / 24);
+  if (days > 0) return `${days}d ago`;
+  if (hrs > 0) return `${hrs}h ago`;
+  if (mins > 0) return `${mins}m ago`;
+  return 'just now';
+}
+
+function aggregateActivity(input: Record<string, Json>): Json {
+  const graphql = input.graphql as Record<string, Json>;
+  const ownerKeys = input.ownerKeys as string[];
+  const nowMs = input.nowMs as number;
+  const updatedAt = input.updatedAt as string;
+
+  let commitsToday = 0;
+  let commitsWeek = 0;
+  const reposActiveToday = new Set<string>();
+  let lastPush: { repo: string; when: string } | null = null;
+
+  for (const key of ownerKeys) {
+    const cc = (graphql[key] as { contributionsCollection?: Json })?.contributionsCollection as
+      | {
+          totalCommitContributions?: number;
+          commitContributionsByRepository?: Array<{
+            repository?: { nameWithOwner?: string; pushedAt?: string };
+            contributions?: { totalCount?: number };
+          }>;
+        }
+      | undefined;
+    if (!cc) continue;
+
+    commitsWeek += cc.totalCommitContributions ?? 0;
+    for (const entry of cc.commitContributionsByRepository ?? []) {
+      const repo = entry.repository?.nameWithOwner ?? '';
+      const count = entry.contributions?.totalCount ?? 0;
+      const pushedAt = entry.repository?.pushedAt;
+      if (!pushedAt) continue;
+      const ts = parseIsoMs(pushedAt);
+      if (nowMs - ts < DAY_MS) {
+        reposActiveToday.add(repo);
+        commitsToday += count;
+      }
+      if (!lastPush || ts > parseIsoMs(lastPush.when)) {
+        lastPush = { repo, when: pushedAt };
+      }
+    }
+  }
+
+  return {
+    commitsToday,
+    commitsWeek,
+    commitsMonth: commitsWeek * 4,
+    reposActiveToday: reposActiveToday.size,
+    lastPush: lastPush
+      ? {
+          repo: lastPush.repo.split('/')[1] ?? lastPush.repo,
+          ago: formatAgo(nowMs, lastPush.when),
+        }
+      : null,
+    updatedAt,
+  };
+}
+
+function simulateBurst(ip: string, base: number): { verdicts: string[]; final: string } {
+  const ipHits = new Map<string, number[]>();
+  const ipDay = new Map<string, number>();
+  let globalDay = Math.floor(base / 86_400_000);
+  let globalCount = 0;
+  const verdicts: string[] = [];
+
+  for (let i = 0; i <= IP_MAX_IN_WINDOW; i += 1) {
+    const now = base + i;
+    const day = Math.floor(now / 86_400_000);
+    if (day !== globalDay) {
+      globalDay = day;
+      globalCount = 0;
+      ipDay.clear();
+      ipHits.clear();
+    }
+    let verdict = 'ok';
+    if (globalCount >= GLOBAL_MAX_PER_DAY) {
+      verdict = 'globalDaily';
+    } else if (ip !== 'unknown') {
+      const dayCount = ipDay.get(ip) ?? 0;
+      if (dayCount >= IP_MAX_PER_DAY) {
+        verdict = 'dailyIp';
+      } else {
+        const hits = (ipHits.get(ip) ?? []).filter((t) => now - t < IP_WINDOW_MS);
+        if (hits.length >= IP_MAX_IN_WINDOW) {
+          verdict = 'tooFast';
+        } else {
+          hits.push(now);
+          ipHits.set(ip, hits);
+          ipDay.set(ip, dayCount + 1);
+        }
+      }
+    }
+    if (verdict === 'ok') {
+      globalCount += 1;
+    }
+    verdicts.push(verdict);
+  }
+
+  return { verdicts, final: verdicts[verdicts.length - 1] ?? 'unknown' };
+}
+
+async function evaluateCase(testCase: CorpusCase): Promise<OracleCase> {
+  switch (testCase.domain) {
+    case 'healthz':
+      return { ...testCase, output: { status: 'ok' } };
+    case 'validPkg':
+      return { ...testCase, output: validPkg(testCase.input.pkg as string) };
+    case 'allowedOrigin':
+      return {
+        ...testCase,
+        output: allowedOrigin(testCase.input.origin as string | undefined),
+      };
+    case 'corsHeaders':
+      return {
+        ...testCase,
+        output: corsHeaders(testCase.input.origin as string | undefined),
+      };
+    case 'clientIp':
+      return {
+        ...testCase,
+        output: clientIp(testCase.input.headers as [string, string][]),
+      };
+    case 'constants':
+      return {
+        ...testCase,
+        output: {
+          ipWindowMs: IP_WINDOW_MS,
+          ipMaxInWindow: IP_MAX_IN_WINDOW,
+          ipMaxPerDay: IP_MAX_PER_DAY,
+          globalMaxPerDay: GLOBAL_MAX_PER_DAY,
+        },
+      };
+    case 'burst': {
+      const burst = simulateBurst(testCase.input.ip as string, testCase.input.base as number);
+      return {
+        ...testCase,
+        output: { verdicts: burst.verdicts, final: burst.final },
+      };
+    }
+    case 'aggregate':
+      return { ...testCase, output: aggregateActivity(testCase.input) };
+    case 'service': {
+      const rel = testCase.input.path as string;
+      const protoPath = join(REPO_ROOT, rel);
+      const raw = await readFile(protoPath, 'utf8');
+      const rpcCount = (raw.match(/\brpc\b/g) ?? []).length;
+      return {
+        ...testCase,
+        output: {
+          service: 'PortfolioApiService',
+          rpcCount,
+          protoHash: sha256Hex(raw),
+        },
+      };
+    }
+    default:
+      throw new Error(`unknown domain: ${testCase.domain}`);
+  }
+}
+
+const manifest = JSON.parse(await readFile(CORPUS_PATH, 'utf8')) as CorpusManifest;
+const cases = await Promise.all(manifest.cases.map((testCase) => evaluateCase(testCase)));
+const fixtureCorpusHash = sha256Hex(JSON.stringify(manifest));
+
+const corpus = {
+  corpusVersion: manifest.corpusVersion,
+  fixtureCorpusHash,
+  cases,
+};
+
+process.stdout.write(`${JSON.stringify(corpus)}\n`);

--- a/scripts/run-portfolio-differential.sh
+++ b/scripts/run-portfolio-differential.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Portfolio API differential parity — TS contract oracle vs Rust contract SSOT.
+# Fail-closed: requires bun (no SKIP-as-pass). See ADR-168 / rej-010.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRATCH="${SCRATCH_DIR:-/tmp/portfolio-api-differential}"
+mkdir -p "$SCRATCH"
+LOG="$SCRATCH/differential.log"
+ARTIFACT="$SCRATCH/verification.json"
+ORACLE_JSON="$SCRATCH/oracle.json"
+SLICE_FILTER="all"
+: >"$LOG"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --slice)
+      SLICE_FILTER="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "::error::unknown argument: $1" | tee -a "$LOG"
+      exit 1
+      ;;
+  esac
+done
+
+case "$SLICE_FILTER" in
+  all|health|pkgValidation|cors|clientIp|rateLimitConstants|activity|proto-contract) ;;
+  *)
+    echo "::error::invalid --slice value: $SLICE_FILTER" | tee -a "$LOG"
+    exit 1
+    ;;
+esac
+
+cd "$REPO_ROOT"
+
+if ! command -v bun >/dev/null 2>&1; then
+  echo "::error::bun required for portfolio differential parity — no SKIP-as-pass" | tee -a "$LOG"
+  exit 1
+fi
+
+echo "=== portfolio API differential parity $(date -Iseconds) slice=${SLICE_FILTER} ===" | tee -a "$LOG"
+
+echo "--- check-no-ts-backend gate ---" | tee -a "$LOG"
+bash "$REPO_ROOT/scripts/check-no-ts-backend.sh" 2>&1 | tee -a "$LOG"
+
+echo "--- build Rust artifacts ---" | tee -a "$LOG"
+(
+  cd "$REPO_ROOT/api-rust"
+  cargo build 2>&1
+) | tee -a "$LOG"
+
+echo "--- TS contract oracle (deleted Bun api/ north-star semantics) ---" | tee -a "$LOG"
+bun run "$REPO_ROOT/scripts/differential/portfolio-api-oracle.ts" >"$ORACLE_JSON" 2>>"$LOG"
+
+run_rust_slice_test() {
+  local label="$1"
+  local test_name="$2"
+  echo "--- Rust bounded slice: $label ---" | tee -a "$LOG"
+  PORTFOLIO_ORACLE_JSON="$ORACLE_JSON" \
+    cargo test --manifest-path "$REPO_ROOT/api-rust/Cargo.toml" --test portfolio_differential "$test_name" -- --nocapture 2>&1 | tee -a "$LOG"
+}
+
+case "$SLICE_FILTER" in
+  health) run_rust_slice_test "health" health_differential_matches_ts_oracle ;;
+  pkgValidation) run_rust_slice_test "pkgValidation" pkg_validation_differential_matches_ts_oracle ;;
+  cors) run_rust_slice_test "cors" cors_differential_matches_ts_oracle ;;
+  clientIp) run_rust_slice_test "clientIp" client_ip_differential_matches_ts_oracle ;;
+  rateLimitConstants)
+    run_rust_slice_test "rateLimitConstants" rate_limit_constants_differential_matches_ts_oracle
+    ;;
+  activity) run_rust_slice_test "activity" activity_differential_matches_ts_oracle ;;
+  proto-contract)
+    run_rust_slice_test "proto-contract" proto_contract_differential_matches_ts_oracle
+    ;;
+  all)
+    run_rust_slice_test "health" health_differential_matches_ts_oracle
+    run_rust_slice_test "pkgValidation" pkg_validation_differential_matches_ts_oracle
+    run_rust_slice_test "cors" cors_differential_matches_ts_oracle
+    run_rust_slice_test "clientIp" client_ip_differential_matches_ts_oracle
+    run_rust_slice_test "rateLimitConstants" rate_limit_constants_differential_matches_ts_oracle
+    run_rust_slice_test "activity" activity_differential_matches_ts_oracle
+    run_rust_slice_test "proto-contract" proto_contract_differential_matches_ts_oracle
+    echo "--- Rust differential test (full corpus) ---" | tee -a "$LOG"
+    PORTFOLIO_ORACLE_JSON="$ORACLE_JSON" \
+      cargo test --manifest-path "$REPO_ROOT/api-rust/Cargo.toml" --test portfolio_differential portfolio_differential_matches_ts_oracle -- --nocapture 2>&1 | tee -a "$LOG"
+    ;;
+esac
+
+CANDIDATE_SHA="${CANDIDATE_SHA:-$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo unknown)}"
+BASELINE_TS_SHA="$(git -C "$REPO_ROOT" log -1 --format=%H -- scripts/differential api-rust/src/contract.rs api-rust/tests/portfolio_differential.rs 2>/dev/null || echo unknown)"
+RUST_SHA="$CANDIDATE_SHA"
+BEHAVIOR_SPEC_HASH="$(sha256sum "$REPO_ROOT/scripts/differential/fixtures/portfolio-api-corpus.json" "$REPO_ROOT/docs/specs/portfolio-api-parity-slice.json" 2>/dev/null | awk '{print $1}' | sha256sum | awk '{print $1}' || echo missing)"
+FIXTURE_CORPUS_HASH="$(jq -r '.fixtureCorpusHash' "$ORACLE_JSON")"
+CONTRACT_HASH="$(sha256sum "$REPO_ROOT/api-rust/src/contract.rs" 2>/dev/null | awk '{print $1}' || echo missing)"
+CASE_COUNT="$(jq '.cases | length' "$ORACLE_JSON")"
+HEALTH_CASES="$(jq '[.cases[] | select(.slice == "health")] | length' "$ORACLE_JSON")"
+PKG_CASES="$(jq '[.cases[] | select(.slice == "pkgValidation")] | length' "$ORACLE_JSON")"
+CORS_CASES="$(jq '[.cases[] | select(.slice == "cors")] | length' "$ORACLE_JSON")"
+CLIENT_IP_CASES="$(jq '[.cases[] | select(.slice == "clientIp")] | length' "$ORACLE_JSON")"
+RATE_CASES="$(jq '[.cases[] | select(.slice == "rateLimitConstants")] | length' "$ORACLE_JSON")"
+ACTIVITY_CASES="$(jq '[.cases[] | select(.slice == "activity")] | length' "$ORACLE_JSON")"
+PROTO_CASES="$(jq '[.cases[] | select(.slice == "proto-contract")] | length' "$ORACLE_JSON")"
+
+jq -n \
+  --arg verifiedAt "$(date -Iseconds)" \
+  --arg candidateSha "$CANDIDATE_SHA" \
+  --arg baselineTsSha "$BASELINE_TS_SHA" \
+  --arg rustCandidateSha "$RUST_SHA" \
+  --arg behaviorSpecHash "$BEHAVIOR_SPEC_HASH" \
+  --arg fixtureCorpusHash "$FIXTURE_CORPUS_HASH" \
+  --arg contractHash "$CONTRACT_HASH" \
+  --arg sliceFilter "$SLICE_FILTER" \
+  --argjson caseCount "$CASE_COUNT" \
+  --argjson healthCaseCount "$HEALTH_CASES" \
+  --argjson pkgCaseCount "$PKG_CASES" \
+  --argjson corsCaseCount "$CORS_CASES" \
+  --argjson clientIpCaseCount "$CLIENT_IP_CASES" \
+  --argjson rateCaseCount "$RATE_CASES" \
+  --argjson activityCaseCount "$ACTIVITY_CASES" \
+  --argjson protoCaseCount "$PROTO_CASES" \
+  '{
+    schemaVersion: 2,
+    repo: "shtse8/portfolio-website",
+    slice: (if $sliceFilter == "all" then "activity-api|backend-caps" else $sliceFilter end),
+    sliceFilter: $sliceFilter,
+    status: "differential_green",
+    verifiedAt: $verifiedAt,
+    lastComparedMainSha: $candidateSha,
+    mergeGroupSha: $candidateSha,
+    baselineTsSha: $baselineTsSha,
+    rustCandidateSha: $rustCandidateSha,
+    behaviorSpecHash: $behaviorSpecHash,
+    fixtureCorpusHash: $fixtureCorpusHash,
+    contractHash: $contractHash,
+    caseCount: $caseCount,
+    healthCaseCount: $healthCaseCount,
+    pkgCaseCount: $pkgCaseCount,
+    corsCaseCount: $corsCaseCount,
+    clientIpCaseCount: $clientIpCaseCount,
+    rateCaseCount: $rateCaseCount,
+    activityCaseCount: $activityCaseCount,
+    protoCaseCount: $protoCaseCount,
+    harness: "scripts/run-portfolio-differential.sh",
+    differentialTest: "api-rust/tests/portfolio_differential.rs#portfolio_differential_matches_ts_oracle",
+    oracle: "scripts/differential/portfolio-api-oracle.ts",
+    gate: "scripts/check-no-ts-backend.sh",
+    capabilitiesProven: [
+      "api-activity-feed",
+      "api-cors-rate-limit",
+      "api-health-ready",
+      "api-terminal-tools",
+      "proto-portfolio-contract"
+    ]
+  }' >"$ARTIFACT"
+
+echo "portfolio-differential: OK (cases=$CASE_COUNT health=$HEALTH_CASES pkg=$PKG_CASES cors=$CORS_CASES clientIp=$CLIENT_IP_CASES rate=$RATE_CASES activity=$ACTIVITY_CASES proto=$PROTO_CASES corpus=$FIXTURE_CORPUS_HASH)" | tee -a "$LOG"
+echo "verification artifact: $ARTIFACT" | tee -a "$LOG"


### PR DESCRIPTION
## Summary
- Land durable rej-010 differential harness for deleted Bun `api/` north-star semantics vs `api-rust` contract SSOT
- Add `scripts/run-portfolio-differential.sh`, `scripts/check-no-ts-backend.sh`, TS oracle + 22-case corpus, and `api-rust/tests/portfolio_differential.rs`
- Extract `api-rust/src/contract.rs` and wire CI differential gate (fail-closed, no continue-on-error)

## Test plan
- [x] `bash scripts/check-no-ts-backend.sh`
- [x] `bash scripts/run-portfolio-differential.sh` (exit 0, cases=22)
- [x] `cd api-rust && cargo test`

## Proof
- Candidate SHA: `0dc0f7db3194fd7f0b426038792184012b6c041d`
- Base main SHA: `7c590ce107d44596f37082842286456fc670186c`
- Control-plane log: `verification/portfolio-differential-green-2026-07-10-main-7c590ce.log`

**Note:** Does not claim fleet complete or `ts_deleted`. `promotionHold` remains until merge + prod audit pass.