### PR TITLE
chore(ledger): honesty demote incomplete proof caps (PROOF-GAP-58-WAVE-TICK026)

### DIFF
--- a/docs/specs/migration-ledger.json
+++ b/docs/specs/migration-ledger.json
@@ -49,18 +49,18 @@
       "id": "proto-portfolio-contract",
       "domain": "contracts",
       "weight": 5,
-      "state": "authority_rust",
+      "state": "rust_impl",
       "rustSurface": "proto/portfolio/v1/api.proto; buf.yaml",
       "parityTest": "buf.yaml lint STANDARD; proto/portfolio/v1/api.proto service+message SSOT",
       "prodProbe": "buf.build/shtse8/portfolio module path",
       "promotionHold": {
         "active": true,
-        "reason": "rej-010/rej-011 freezes stay \u2014 canary_green+imageDigest admitted at live digest sha256:c77f8468c78503cbc9cd0be717a5741d545a7dafc7253a6c3a884635fba20dd0 (tick023); NO ts_deleted; NO freeze lift",
+        "reason": "rej-010 promotion freeze \u2014 incomplete differential proof; honesty demoted authority_rust\u2192rust_impl (PROOF-GAP-58-WAVE-TICK026)",
         "rejectionRef": "rej-010",
         "since": "2026-07-10T21:30:00Z"
       },
       "proof": {
-        "status": "canary_green",
+        "status": "stale",
         "baselineTsSha": "",
         "rustCandidateSha": "8a36e3d849f4a901b6a8d766e405ff8e4d08c6d9",
         "lastComparedMainSha": "8a36e3d849f4a901b6a8d766e405ff8e4d08c6d9",
@@ -75,9 +75,10 @@
           "scripts/run-portfolio-differential.sh"
         ],
         "contractHash": "358313c76d9b3dc55f8cb4a0ce6d0d06073a834e815d4c18b334f4aef431b324",
-        "imageDigest": "sha256:c77f8468c78503cbc9cd0be717a5741d545a7dafc7253a6c3a884635fba20dd0"
+        "imageDigest": "sha256:c77f8468c78503cbc9cd0be717a5741d545a7dafc7253a6c3a884635fba20dd0",
+        "staleReason": "PROOF-GAP-58-WAVE-TICK026 honesty demote: promoted state without valid v2 proof. Prior state=authority_rust. rej-010."
       },
-      "notes": "Protobuf+Buf contract stack; REST handlers mirror proto messages (Connect codegen next slice). TICK023: proof.status=canary_green + imageDigest bound at sha256:c77f8468c78503cbc9cd0be717a5741d545a7dafc7253a6c3a884635fba20dd0 (SYLPHX_GIT_COMMIT_SHA=8a36e3d849f4a901b6a8d766e405ff8e4d08c6d9); prod reconfirm smoke; state unchanged; NO ts_deleted. Evidence: proto contract live via api-rust handlers; differential 22-case main-proof incl proto=1; prod_audit_pass tick006 + live reconfirm tick023."
+      "notes": "Protobuf+Buf contract stack; REST handlers mirror proto messages (Connect codegen next slice). TICK023: proof.status=canary_green + imageDigest bound at sha256:c77f8468c78503cbc9cd0be717a5741d545a7dafc7253a6c3a884635fba20dd0 (SYLPHX_GIT_COMMIT_SHA=8a36e3d849f4a901b6a8d766e405ff8e4d08c6d9); prod reconfirm smoke; state unchanged; NO ts_deleted. Evidence: proto contract live via api-rust handlers; differential 22-case main-proof incl proto=1; prod_audit_pass tick006 + live reconfirm tick023. [PROOF-GAP-58-WAVE-TICK026] honesty demote authority_rust\u2192rust_impl (invalid/missing v2 proof)."
     },
     {
       "id": "api-health-ready",
@@ -117,68 +118,68 @@
       "id": "api-stats-github-npm",
       "domain": "api-edge",
       "weight": 5,
-      "state": "authority_rust",
+      "state": "rust_impl",
       "rustSurface": "api-rust/src/stats.rs#/stats",
       "parityTest": "api-rust/tests/parity.rs; api-rust/tests/http_smoke.rs",
       "prodProbe": "scripts/api-smoke.sh GET /stats",
       "promotionHold": {
         "active": true,
-        "reason": "rej-010 hold \u2014 not canary-admitted in tick023: prod smoke green but proof.status remains missing \u2014 no SHA-bound differential corpus (scorecard residual #2)",
+        "reason": "rej-010 promotion freeze \u2014 incomplete differential proof; honesty demoted authority_rust\u2192rust_impl (PROOF-GAP-58-WAVE-TICK026)",
         "rejectionRef": "rej-010",
         "since": "2026-07-10T21:30:00Z"
       },
       "proof": {
-        "status": "missing",
+        "status": "stale",
         "dependencyGlobs": [
           "api-rust/src/stats.rs"
         ],
-        "staleReason": "rej-010 re-audit \u2014 prior ts_deleted lacked SHA-bound differential proof",
+        "staleReason": "PROOF-GAP-58-WAVE-TICK026 honesty demote: promoted state without valid v2 proof. Prior state=authority_rust. rej-010.",
         "verificationRef": "scripts/api-smoke.sh"
       },
-      "notes": "GitHub GraphQL + npm aggregate stats with 10-minute TTL cache."
+      "notes": "GitHub GraphQL + npm aggregate stats with 10-minute TTL cache. [PROOF-GAP-58-WAVE-TICK026] honesty demote authority_rust\u2192rust_impl (invalid/missing v2 proof)."
     },
     {
       "id": "api-chat-agent-sse",
       "domain": "api-edge",
       "weight": 5,
-      "state": "authority_rust",
+      "state": "rust_impl",
       "rustSurface": "api-rust/src/chat.rs#/chat; api-rust/src/persona.rs",
       "parityTest": "api-rust/tests/http_smoke.rs integration",
       "prodProbe": "scripts/api-smoke.sh POST /chat SSE text-delta",
       "promotionHold": {
         "active": true,
-        "reason": "rej-010 hold \u2014 not canary-admitted in tick023: SSE chat not prod-smoked this packet; proof.status remains missing (scorecard residual #2)",
+        "reason": "rej-010 promotion freeze \u2014 incomplete differential proof; honesty demoted authority_rust\u2192rust_impl (PROOF-GAP-58-WAVE-TICK026)",
         "rejectionRef": "rej-010",
         "since": "2026-07-10T21:30:00Z"
       },
       "proof": {
-        "status": "missing",
+        "status": "stale",
         "dependencyGlobs": [
           "api-rust/src/chat.rs",
           "api-rust/src/persona.rs"
         ],
-        "staleReason": "rej-010 re-audit \u2014 prior ts_deleted lacked SHA-bound differential proof",
+        "staleReason": "PROOF-GAP-58-WAVE-TICK026 honesty demote: promoted state without valid v2 proof. Prior state=authority_rust. rej-010.",
         "verificationRef": "scripts/api-smoke.sh"
       },
-      "notes": "AI SDK-compatible SSE stream via Sylphx AI Gateway."
+      "notes": "AI SDK-compatible SSE stream via Sylphx AI Gateway. [PROOF-GAP-58-WAVE-TICK026] honesty demote authority_rust\u2192rust_impl (invalid/missing v2 proof)."
     },
     {
       "id": "api-terminal-tools",
       "domain": "api-edge",
       "weight": 4,
-      "state": "authority_rust",
+      "state": "rust_impl",
       "rustSurface": "api-rust/src/tools.rs; GET /projects, /repo, /recent, /downloads",
       "parityTest": "api-rust/tests/parity.rs#pkg_validation_matches_bun_rules",
       "differentialTest": "api-rust/tests/portfolio_differential.rs#pkgValidation",
       "prodProbe": "scripts/api-smoke.sh GET /projects",
       "promotionHold": {
         "active": true,
-        "reason": "rej-010/rej-011 freezes stay \u2014 canary_green+imageDigest admitted at live digest sha256:c77f8468c78503cbc9cd0be717a5741d545a7dafc7253a6c3a884635fba20dd0 (tick023); NO ts_deleted; NO freeze lift",
+        "reason": "rej-010 promotion freeze \u2014 incomplete differential proof; honesty demoted authority_rust\u2192rust_impl (PROOF-GAP-58-WAVE-TICK026)",
         "rejectionRef": "rej-010",
         "since": "2026-07-10T21:30:00Z"
       },
       "proof": {
-        "status": "canary_green",
+        "status": "stale",
         "baselineTsSha": "",
         "rustCandidateSha": "8a36e3d849f4a901b6a8d766e405ff8e4d08c6d9",
         "lastComparedMainSha": "8a36e3d849f4a901b6a8d766e405ff8e4d08c6d9",
@@ -192,27 +193,28 @@
           "api-rust/src/contract.rs",
           "scripts/differential/**"
         ],
-        "imageDigest": "sha256:c77f8468c78503cbc9cd0be717a5741d545a7dafc7253a6c3a884635fba20dd0"
+        "imageDigest": "sha256:c77f8468c78503cbc9cd0be717a5741d545a7dafc7253a6c3a884635fba20dd0",
+        "staleReason": "PROOF-GAP-58-WAVE-TICK026 honesty demote: promoted state without valid v2 proof. Prior state=authority_rust. rej-010."
       },
-      "notes": "Terminal + agent tool surface; pkg validation in differential corpus. TICK023: proof.status=canary_green + imageDigest bound at sha256:c77f8468c78503cbc9cd0be717a5741d545a7dafc7253a6c3a884635fba20dd0 (SYLPHX_GIT_COMMIT_SHA=8a36e3d849f4a901b6a8d766e405ff8e4d08c6d9); prod reconfirm smoke; state unchanged; NO ts_deleted. Evidence: GET /projects 200 projects[] n=12 @ 2026-07-11T11:06:19Z."
+      "notes": "Terminal + agent tool surface; pkg validation in differential corpus. TICK023: proof.status=canary_green + imageDigest bound at sha256:c77f8468c78503cbc9cd0be717a5741d545a7dafc7253a6c3a884635fba20dd0 (SYLPHX_GIT_COMMIT_SHA=8a36e3d849f4a901b6a8d766e405ff8e4d08c6d9); prod reconfirm smoke; state unchanged; NO ts_deleted. Evidence: GET /projects 200 projects[] n=12 @ 2026-07-11T11:06:19Z. [PROOF-GAP-58-WAVE-TICK026] honesty demote authority_rust\u2192rust_impl (invalid/missing v2 proof)."
     },
     {
       "id": "api-activity-feed",
       "domain": "api-edge",
       "weight": 2,
-      "state": "authority_rust",
+      "state": "rust_impl",
       "rustSurface": "api-rust/src/activity.rs; api-rust/src/contract.rs; GET /activity",
       "parityTest": "api-rust/tests/portfolio_differential.rs#activity",
       "differentialTest": "api-rust/tests/portfolio_differential.rs#activity",
       "prodProbe": "scripts/api-smoke.sh GET /activity; deploy digest readback (rej-002)",
       "promotionHold": {
         "active": true,
-        "reason": "rej-010/rej-011 freezes stay \u2014 canary_green+imageDigest admitted at live digest sha256:c77f8468c78503cbc9cd0be717a5741d545a7dafc7253a6c3a884635fba20dd0 (tick023); NO ts_deleted; NO freeze lift",
+        "reason": "rej-010 promotion freeze \u2014 incomplete differential proof; honesty demoted authority_rust\u2192rust_impl (PROOF-GAP-58-WAVE-TICK026)",
         "rejectionRef": "rej-010",
         "since": "2026-07-10T21:30:00Z"
       },
       "proof": {
-        "status": "canary_green",
+        "status": "stale",
         "baselineTsSha": "",
         "rustCandidateSha": "8a36e3d849f4a901b6a8d766e405ff8e4d08c6d9",
         "lastComparedMainSha": "8a36e3d849f4a901b6a8d766e405ff8e4d08c6d9",
@@ -227,27 +229,28 @@
           "scripts/differential/**",
           "scripts/run-portfolio-differential.sh"
         ],
-        "imageDigest": "sha256:c77f8468c78503cbc9cd0be717a5741d545a7dafc7253a6c3a884635fba20dd0"
+        "imageDigest": "sha256:c77f8468c78503cbc9cd0be717a5741d545a7dafc7253a6c3a884635fba20dd0",
+        "staleReason": "PROOF-GAP-58-WAVE-TICK026 honesty demote: promoted state without valid v2 proof. Prior state=authority_rust. rej-010."
       },
-      "notes": "LiveTicker /activity \u2014 GraphQL contributionsCollection aggregation in contract SSOT; rej-002 blocks canary until deploy readback. TICK023: proof.status=canary_green + imageDigest bound at sha256:c77f8468c78503cbc9cd0be717a5741d545a7dafc7253a6c3a884635fba20dd0 (SYLPHX_GIT_COMMIT_SHA=8a36e3d849f4a901b6a8d766e405ff8e4d08c6d9); prod reconfirm smoke; state unchanged; NO ts_deleted. Evidence: GET /activity 200 ActivityPayload (commitsToday/Week/Month, reposActiveToday, updatedAt) no error envelope @ 2026-07-11T11:06:19Z; rej-002 closed."
+      "notes": "LiveTicker /activity \u2014 GraphQL contributionsCollection aggregation in contract SSOT; rej-002 blocks canary until deploy readback. TICK023: proof.status=canary_green + imageDigest bound at sha256:c77f8468c78503cbc9cd0be717a5741d545a7dafc7253a6c3a884635fba20dd0 (SYLPHX_GIT_COMMIT_SHA=8a36e3d849f4a901b6a8d766e405ff8e4d08c6d9); prod reconfirm smoke; state unchanged; NO ts_deleted. Evidence: GET /activity 200 ActivityPayload (commitsToday/Week/Month, reposActiveToday, updatedAt) no error envelope @ 2026-07-11T11:06:19Z; rej-002 closed. [PROOF-GAP-58-WAVE-TICK026] honesty demote authority_rust\u2192rust_impl (invalid/missing v2 proof)."
     },
     {
       "id": "api-cors-rate-limit",
       "domain": "api-edge",
       "weight": 2,
-      "state": "authority_rust",
+      "state": "rust_impl",
       "rustSurface": "api-rust/src/cors.rs; api-rust/src/rate_limit.rs; api-rust/src/contract.rs",
       "parityTest": "api-rust/src/rate_limit.rs#rate_limit_blocks_burst",
       "differentialTest": "api-rust/tests/portfolio_differential.rs#cors|clientIp|rateLimitConstants",
       "prodProbe": "api-rust cargo test; CORS headers on all JSON handlers",
       "promotionHold": {
         "active": true,
-        "reason": "rej-010/rej-011 freezes stay \u2014 canary_green+imageDigest admitted at live digest sha256:c77f8468c78503cbc9cd0be717a5741d545a7dafc7253a6c3a884635fba20dd0 (tick023); NO ts_deleted; NO freeze lift",
+        "reason": "rej-010 promotion freeze \u2014 incomplete differential proof; honesty demoted authority_rust\u2192rust_impl (PROOF-GAP-58-WAVE-TICK026)",
         "rejectionRef": "rej-010",
         "since": "2026-07-10T21:30:00Z"
       },
       "proof": {
-        "status": "canary_green",
+        "status": "stale",
         "baselineTsSha": "",
         "rustCandidateSha": "8a36e3d849f4a901b6a8d766e405ff8e4d08c6d9",
         "lastComparedMainSha": "8a36e3d849f4a901b6a8d766e405ff8e4d08c6d9",
@@ -262,9 +265,10 @@
           "api-rust/src/contract.rs",
           "scripts/differential/**"
         ],
-        "imageDigest": "sha256:c77f8468c78503cbc9cd0be717a5741d545a7dafc7253a6c3a884635fba20dd0"
+        "imageDigest": "sha256:c77f8468c78503cbc9cd0be717a5741d545a7dafc7253a6c3a884635fba20dd0",
+        "staleReason": "PROOF-GAP-58-WAVE-TICK026 honesty demote: promoted state without valid v2 proof. Prior state=authority_rust. rej-010."
       },
-      "notes": "CORS allowlist + per-IP chat rate limit; contract helpers in differential corpus. TICK023: proof.status=canary_green + imageDigest bound at sha256:c77f8468c78503cbc9cd0be717a5741d545a7dafc7253a6c3a884635fba20dd0 (SYLPHX_GIT_COMMIT_SHA=8a36e3d849f4a901b6a8d766e405ff8e4d08c6d9); prod reconfirm smoke; state unchanged; NO ts_deleted. Evidence: Access-Control-Allow-Origin observed on /activity /stats /projects JSON handlers @ 2026-07-11T11:06:19Z; differential cors/clientIp/rate cases green on main."
+      "notes": "CORS allowlist + per-IP chat rate limit; contract helpers in differential corpus. TICK023: proof.status=canary_green + imageDigest bound at sha256:c77f8468c78503cbc9cd0be717a5741d545a7dafc7253a6c3a884635fba20dd0 (SYLPHX_GIT_COMMIT_SHA=8a36e3d849f4a901b6a8d766e405ff8e4d08c6d9); prod reconfirm smoke; state unchanged; NO ts_deleted. Evidence: Access-Control-Allow-Origin observed on /activity /stats /projects JSON handlers @ 2026-07-11T11:06:19Z; differential cors/clientIp/rate cases green on main. [PROOF-GAP-58-WAVE-TICK026] honesty demote authority_rust\u2192rust_impl (invalid/missing v2 proof)."
     },
     {
       "id": "bun-api-authority",
@@ -382,7 +386,7 @@
     "total": 10,
     "ts_only": 2,
     "contracted": 0,
-    "rust_impl": 2,
+    "rust_impl": 8,
     "parity_proven": 0,
     "authority_rust": 6,
     "ts_deleted": 0,
@@ -420,7 +424,9 @@
       ],
       "promotions": 0,
       "policy": "map TICK024 highSignalUnmapped as ts_only only; no promotions"
-    }
+    },
+    "updatedAt": "2026-07-11T14:07:29Z",
+    "lastMutation": "PROOF-GAP-58-WAVE-TICK026"
   },
   "priorClaims": {
     "ts_deleted": 8,
@@ -557,6 +563,42 @@
       "lift_rej-011",
       "REPO_COMPLETE",
       "cluster_mutation"
+    ]
+  },
+  "rej010HonestyDemote": {
+    "packetId": "PROOF-GAP-58-WAVE-TICK026",
+    "appliedAt": "2026-07-11T14:07:29Z",
+    "demoted": [
+      {
+        "id": "proto-portfolio-contract",
+        "from": "authority_rust",
+        "to": "rust_impl"
+      },
+      {
+        "id": "api-stats-github-npm",
+        "from": "authority_rust",
+        "to": "rust_impl"
+      },
+      {
+        "id": "api-chat-agent-sse",
+        "from": "authority_rust",
+        "to": "rust_impl"
+      },
+      {
+        "id": "api-terminal-tools",
+        "from": "authority_rust",
+        "to": "rust_impl"
+      },
+      {
+        "id": "api-activity-feed",
+        "from": "authority_rust",
+        "to": "rust_impl"
+      },
+      {
+        "id": "api-cors-rate-limit",
+        "from": "authority_rust",
+        "to": "rust_impl"
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary

Honesty demotion for control-plane packet `PROOF-GAP-58-WAVE-TICK026` (rej-010).

Promoted capabilities lacked valid v2 proof fields (`baselineTsSha`, `rustCandidateSha`, `lastComparedMainSha`, fixture/verificationRef, `differentialTest`, and/or valid `proof.status` in differential_green|caught_up|canary_green).

### Demotions (6)

| Capability | From | To |
| --- | --- | --- |
| `proto-portfolio-contract` | `authority_rust` | `rust_impl` |
| `api-stats-github-npm` | `authority_rust` | `rust_impl` |
| `api-chat-agent-sse` | `authority_rust` | `rust_impl` |
| `api-terminal-tools` | `authority_rust` | `rust_impl` |
| `api-activity-feed` | `authority_rust` | `rust_impl` |
| `api-cors-rate-limit` | `authority_rust` | `rust_impl` |

### Policy

- **No** `authority_rust` / `ts_deleted` promotions (freeze)
- Gates not weakened — demote state/proof to match reality
- `promotionHold.active=true` with rej-010 reason
- `proof.status=stale` with packet staleReason

### Test plan

- [ ] CI green
- [ ] Ledger JSON valid
- [ ] Demoted caps all `rust_impl`
- [ ] No new authority_rust/ts_deleted
