### PR TITLE
fix(api-rust): drop-in residual harden — EnvGuard + fail-closed activity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Test api-rust (unit/contract/wiremock; skip differential spawn path)
         working-directory: api-rust
-        run: cargo test --locked -- --test-threads=1 --skip differential_matches_ts_oracle
+        run: cargo test --locked --jobs 1 -- --test-threads=1 --skip differential_matches_ts_oracle
 
       - name: No TS backend authority (ADR-168 S3)
         run: bash scripts/check-no-ts-backend.sh

--- a/api-rust/src/app.rs
+++ b/api-rust/src/app.rs
@@ -151,8 +151,9 @@ pub async fn activity_handler(headers: HeaderMap) -> Response {
             if let Some(stale) = activity::cached_snapshot() {
                 return json_value_with_cors(crate::rest_projection::activity_json_stale(&stale), origin.as_deref());
             }
-            json_value_with_cors(
-                json!({ "error": "activity data briefly unavailable" }),
+            error_json(
+                StatusCode::BAD_GATEWAY,
+                "activity data briefly unavailable",
                 origin.as_deref(),
             )
         }

--- a/api-rust/src/testing.rs
+++ b/api-rust/src/testing.rs
@@ -1,5 +1,47 @@
 //! Test-only reset hooks for integration/wiremock suites.
 
+use std::sync::{Mutex, MutexGuard};
+
+/// Process-wide lock for tests that mutate process env + static caches.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+#[doc(hidden)]
+pub struct EnvGuard {
+    _lock: MutexGuard<'static, ()>,
+    keys: Vec<String>,
+}
+
+impl EnvGuard {
+    pub fn acquire(keys: &[&str]) -> Self {
+        let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        crate::stats::reset_cache_for_tests();
+        crate::activity::reset_cache_for_tests();
+        crate::tools::reset_repos_cache_for_tests();
+        crate::rate_limit::reset_state_for_tests();
+        Self {
+            _lock: lock,
+            keys: keys.iter().map(|s| (*s).to_string()).collect(),
+        }
+    }
+
+    pub fn set(&self, key: &str, value: &str) {
+        // SAFETY: held under ENV_LOCK; tests serialise env mutation via this guard.
+        unsafe { std::env::set_var(key, value) };
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for key in &self.keys {
+            unsafe { std::env::remove_var(key) };
+        }
+        crate::stats::reset_cache_for_tests();
+        crate::activity::reset_cache_for_tests();
+        crate::tools::reset_repos_cache_for_tests();
+        crate::rate_limit::reset_state_for_tests();
+    }
+}
+
 #[doc(hidden)]
 pub fn reset_all() {
     crate::stats::reset_cache_for_tests();

--- a/api-rust/tests/http_smoke.rs
+++ b/api-rust/tests/http_smoke.rs
@@ -4,21 +4,38 @@ use std::time::Duration;
 #[test]
 fn healthz_returns_ok_on_real_binary() {
     let bin = env!("CARGO_BIN_EXE_kylet-api-rust");
+    let port = 39081u16;
     let mut child = Command::new(bin)
-        .env("PORT", "39081")
+        .env("PORT", port.to_string())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
         .expect("spawn kylet-api-rust");
 
-    std::thread::sleep(Duration::from_millis(400));
-
-    let output = Command::new("curl")
-        .args(["-sf", "http://127.0.0.1:39081/healthz"])
-        .output()
-        .expect("curl healthz");
-
+    let url = format!("http://127.0.0.1:{port}/healthz");
+    let mut last = None;
+    for _ in 0..20 {
+        std::thread::sleep(Duration::from_millis(100));
+        let output = Command::new("curl").args(["-sf", &url]).output();
+        match output {
+            Ok(out) if out.status.success() => {
+                let body = String::from_utf8_lossy(&out.stdout).trim().to_string();
+                let _ = child.kill();
+                let _ = child.wait();
+                assert_eq!(body, "ok");
+                return;
+            }
+            Ok(out) => {
+                last = Some(format!(
+                    "status={:?} stderr={}",
+                    out.status,
+                    String::from_utf8_lossy(&out.stderr)
+                ))
+            }
+            Err(e) => last = Some(format!("curl spawn err: {e}")),
+        }
+    }
     let _ = child.kill();
-    assert!(output.status.success(), "curl failed: {:?}", output);
-    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "ok");
+    let _ = child.wait();
+    panic!("healthz not ready after retries: {last:?}");
 }

--- a/api-rust/tests/wiremock_activity.rs
+++ b/api-rust/tests/wiremock_activity.rs
@@ -12,12 +12,17 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 #[serial]
 async fn activity_endpoint_aggregates_wiremock_graphql() {
     let server = MockServer::start().await;
-    // GITHUB_API_BASE override must pin GraphQL (GHA injects GITHUB_GRAPHQL_URL).
-    unsafe {
-        std::env::set_var("GITHUB_API_BASE", server.uri());
-        std::env::set_var("GITHUB_TOKEN", "wiremock-token");
-    }
-    testing::reset_all();
+    // GHA injects GITHUB_GRAPHQL_URL; EnvGuard clears it so GITHUB_API_BASE pins GraphQL.
+    let env = testing::EnvGuard::acquire(&[
+        "GITHUB_API_BASE",
+        "GITHUB_TOKEN",
+        "GITHUB_GRAPHQL_URL",
+    ]);
+    env.set("GITHUB_API_BASE", &server.uri());
+    env.set("GITHUB_TOKEN", "wiremock-token");
+    // Explicitly drop any GHA GraphQL override (removed via EnvGuard keys on drop too).
+    unsafe { std::env::remove_var("GITHUB_GRAPHQL_URL") };
+    let _env = env;
 
     Mock::given(method("POST"))
         .and(path("/graphql"))
@@ -43,14 +48,20 @@ async fn activity_endpoint_aggregates_wiremock_graphql() {
         .oneshot(Request::builder().uri("/activity").body(Body::empty()).unwrap())
         .await
         .unwrap();
-    assert_eq!(res.status(), StatusCode::OK);
-    let bytes = axum::body::to_bytes(res.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(
+        res.status(),
+        StatusCode::OK,
+        "activity must succeed against wiremock upstream"
+    );
+    let bytes = axum::body::to_bytes(res.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
     assert!(
         v.get("error").is_none(),
         "activity must not be error payload under wiremock: {v}"
     );
     assert_eq!(v["commitsWeek"], 5, "body={v}");
-    assert!(v.get("commitsToday").is_some());
-    assert!(v.get("lastPush").is_some());
+    assert_eq!(v["commitsToday"], 2, "body={v}");
+    assert!(v.get("lastPush").is_some(), "body={v}");
 }


### PR DESCRIPTION
## Summary

Follow-up to #24 (merged). Hardens drop-in residual CI and production error surface:

- **EnvGuard** for wiremock suites (clears GHA-injected `GITHUB_GRAPHQL_URL` when present)
- **`/activity` hard errors → 502** (fail-closed; no OK + error envelope with null fields)
- **`http_smoke` readiness retries** (flake under slow spawn)
- **CI**: `cargo test --jobs 1` for process-env isolation

GraphQL wiremock pin (`GITHUB_API_BASE` overrides `GITHUB_GRAPHQL_URL`) already on main via #24.

## Local proof
```
GITHUB_GRAPHQL_URL=https://api.github.com/graphql \
  cargo test --locked --jobs 1 --test wiremock_activity -- --test-threads=1
# ok
```

## Honesty
- no authority_rust / ts_deleted / freeze lift
- Packet: `FLEET-35-SITES-DROPIN-RESIDUAL`