### PR TITLE
feat(ci): migrate to Agent-native Fast Trunk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,19 @@
 name: CI
 
+# Fast Trunk (Agent-native):
+# - Aggregate source verdict: source-ci/pass
+# - CI = source correctness only; Platform builds production once
+# - Merge Queue off by default (no merge_group trigger)
+# - Concurrency cancels superseded PR/branch tip runs
+
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
-  merge_group:
-    types: [checks_requested]
-
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Fast Trunk: supersede obsolete runs for the same PR or branch tip.
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/docs/reference/fast-trunk-ci.md
+++ b/docs/reference/fast-trunk-ci.md
@@ -1,0 +1,31 @@
+# Fast Trunk CI
+
+## Authority split
+
+| Concern | Owner |
+| --- | --- |
+| Work / claim / review | Enact |
+| Source history | Git |
+| Source correctness | This repository CI (`source-ci/pass`) |
+| Production artifact build | Sylphx Platform (once) |
+| Deploy / health / rollback | Sylphx Platform |
+
+## Paths
+
+- **Internal agents:** small-batch non-force direct-trunk to default branch.
+- **External contributors:** Pull Request presubmit feedback.
+- **Merge Queue:** default off (no `merge_group` trigger).
+
+## CI scope
+
+Blocking: lint/typecheck, affected tests, schema/migration safety, narrow security.
+
+Not in source CI: production Docker/release image builds, disposable ship binaries for ordinary tips.
+
+## Concurrency
+
+```yaml
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+```


### PR DESCRIPTION
## Summary
Fleet Fast Trunk migration:
- cancel-in-progress concurrency by PR/ref
- no merge_group (MQ off)
- docs: CI=source, Platform=build once
- source-ci/pass aggregate where trunk-admission existed

## Test plan
- [ ] CI workflow admits
