### PR TITLE
KYLE: keep kylet.se proof surface truthful

### DIFF
--- a/src/components/FloatingAgent.tsx
+++ b/src/components/FloatingAgent.tsx
@@ -121,6 +121,18 @@ export default function FloatingAgent() {
     };
   }, []);
 
+  // A configured gateway can still fail at request time (for example when its
+  // auth service is unavailable). Fail closed on the first stream error so a
+  // broken agent never remains as public UI theater; the mailto fallback stays
+  // available through the normal chatReady=false branch.
+  useEffect(() => {
+    if (!error) return;
+    setChatReady(false);
+    setOpen(false);
+    setShowHint(false);
+    pendingSeed.current = null;
+  }, [error]);
+
   // Cmd+K / Ctrl+K to open agent (power-user shortcut)
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -342,7 +354,7 @@ export default function FloatingAgent() {
                       Ask my AI
                     </div>
                     <div className="font-mono text-[10px] text-text-tertiary">
-                      Powered by sylphx/lumen · Gateway
+                      Powered by Sylphx AI Gateway · live tools
                     </div>
                   </div>
                 </div>

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -42,7 +42,7 @@ export const PROJECTS: Project[] = [
       "Built MCP server for PDF processing with parallel processing support",
       "Implemented Y-coordinate based layout preservation for natural reading flow",
       "Supports local files (Windows/Unix) and HTTP/HTTPS URLs",
-      "801 GitHub stars · 24K+ npm downloads/month · 94%+ test coverage (103 passing tests)",
+      "Live GitHub stars and npm downloads are shown in the evidence graph above; testing and performance details live in the linked repository.",
       "Integrated with Claude Code, Claude Desktop, VS Code, Cursor, Windsurf, and Smithery",
       "Published on NPM as @sylphx/pdf-reader-mcp",
     ],

--- a/sylphx.toml
+++ b/sylphx.toml
@@ -27,7 +27,7 @@ service = "api"
 name = "web"
 type = "web"
 port = 3000
-# Transitional until edge routing is live: nginx proxies /activity|/stats|/chat|/healthz → api:3001.
+# Transitional until edge routing is live: nginx proxies the API paths → api:3001.
 # Platform injects API_INTERNAL_URL and opens NetworkPolicy web→api.
 connect = { services = ["api"] }
 watch_paths = ["src/**", "public/**", "package.json", "nginx.conf", "Dockerfile", "sylphx.toml"]
@@ -39,7 +39,7 @@ port = 3001
 deploy_priority = 100
 # Shared-host path routing: the edge sends these prefixes directly to this
 # service; web keeps catch-all `/` on kylet.se.
-path_prefixes = ["/stats", "/activity", "/projects", "/recent", "/repo", "/downloads", "/chat", "/healthz"]
+path_prefixes = ["/stats", "/activity", "/projects", "/recent", "/repo", "/downloads", "/claims", "/chat", "/healthz"]
 # Chat requires server-side env (project secrets): SYLPHX_AI_URL + SYLPHX_AI_API_KEY
 # (or AI_GATEWAY_BASE_URL/AI_GATEWAY_KEY). SYLPHX_URL is the public browser URL and
 # must never be used. Without a credential /chat fails closed with 503.


### PR DESCRIPTION
## Scope
KYLE personal website only. Static Next export, Rust API, and the declared kylet.se edge boundary remain the project-owned surfaces; no Platform or Gateway internals are changed.

## Changes
- Remove the stale hard-coded flagship traction sentence; keep live stars/downloads sourced from the evidence graph.
- Route `/claims` through the declared API service path.
- Fail the public chat closed after a runtime Gateway stream error, and use truthful Gateway branding instead of a stale model label.

## Validation
- `bun run check`
- `bun run build`
- `bun run test:cinematic`
- `git diff --check`
- Static preview browser smoke: HTTP 200, clean console/page-error gate; runtime synthetic SSE error reaches the Email Kyle fallback.

## State
Source candidate only until merged; no live claim. Current external edges remain separate: kylet.se custom-domain API routes return 502, while the preview Gateway readiness endpoint reports ready but chat requests return an authentication-service 503. These are Platform/Gateway-owned blockers, not source workarounds.