### PR TITLE
KYLE: hard-cut CI to Sylphx owned runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   web:
     name: Web (biome, tsc, tests, static export)
-    runs-on: ubuntu-latest
+    runs-on: sylphx-linux-standard
     steps:
       - uses: actions/checkout@v4
 
@@ -49,7 +49,7 @@ jobs:
 
   api:
     name: Rust API (clippy, tests)
-    runs-on: ubuntu-latest
+    runs-on: sylphx-linux-standard
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- replace both current CI jobs' GitHub-hosted selectors with the static Sylphx-owned profile `sylphx-linux-standard`
- keep the existing web and Rust product checks unchanged
- provide no hosted, dynamic, generic self-hosted, or runner-capacity fallback

## Validation
- workflow YAML parsed; both jobs resolve to `sylphx-linux-standard`
- no hosted or dynamic runner selectors remain in `.github/workflows`
- `bun run check`
- `bun run build`
- `cargo test --locked`
- `cargo clippy --locked --lib --bins -- -D warnings`
- `git diff --check`

Platform runner capacity and the existing production Platform/Gateway blockers remain external and are not altered by this source-only correction.