### PR TITLE
docs: publish current GitHub listing and product URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
-# portfolio-website — kylet.se
+# kylet.se
 
-Kyle Tse's personal portfolio (`kylet.se`): a static marketing site with a small
-Rust live API. Clean-break contract model per [ADR-169](./docs/adr/ADR-169-contract-simplification-clean-break.md).
+Kyle Tse's personal proof surface: a static portfolio with a small Rust live API for evidence and the on-site agent.
+
+- Ordinary: https://kylet.se — customer domain for this personal proof surface. HTML reachability is not the product contract.
+- Preview: none — no product-owned current preview URL is declared. `https://portfolio-website-phi-six-53.vercel.app` is a leftover Vercel host, not production.
+- Vision: [docs/vision.md](docs/vision.md)
+- Capabilities: [docs/capabilities.md](docs/capabilities.md)
+- Decisions: [docs/adr/](docs/adr/)
 
 ## Stack
 


### PR DESCRIPTION
## Slice

META-KYLE listing only: keep `README.md` and the GitHub repository listing on the same current product truth.

## Change

- README now states one-sentence purpose, ordinary URL, preview, vision, capabilities, and decisions.
- Ordinary: https://kylet.se — customer domain named by `docs/vision.md`, `sylphx.toml`, and the live HTML `og:url`.
- Preview: none — no product-owned current preview URL is declared.
- GitHub description is the same one-sentence purpose. Homepage is https://kylet.se (`gh repo edit` on this PR).

## Verified, not assumed

- GitHub listing before this PR: empty description; homepage `https://portfolio-website-phi-six-53.vercel.app`.
- `https://kylet.se` returns the portfolio HTML (`Kyle Tse — AI infrastructure builder`). `https://www.kylet.se` redirects to the apex.
- HTML 200 is not the product contract. At observation, `/healthz`, `/stats`, and `/chat/ready` on kylet.se returned 502.
- The leftover Vercel alias still answers 200. GitHub still records Vercel Preview/Production deployments; the latest hashed “Production” URL (`portfolio-website-mux17eiaa-epiow.vercel.app`) requires Vercel SSO. That is not production and not a product-owned preview.
- CORS still allowlists historical `*.sylphx.app` hosts. `slim-pal-0k3stq.sylphx.app` is 404. `loud-slab-t9c6ai.sylphx.app` serves the same 2026-08-10 static web last-modified as kylet.se. Neither is published here as a current preview.

## Residual, outside this write-set

- `src/data/github-portfolio.json` still repeats the leftover Vercel homepage from the previous GitHub listing.
- Live API/agent proof remains a separate delivery/live node. This PR does not claim kylet.se is fully live.

## Oracle

- README names ordinary + preview.
- GitHub description matches the README sentence.
- GitHub homepage is https://kylet.se.
- Vercel is not presented as production.