### PR TITLE
fix(hero): never label baked proof-board stats as live

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -6,7 +6,8 @@ import { useNavigationStore } from "@/context/NavigationContext";
 import { type HighlightKind, useWorkGraph } from "@/context/WorkGraphContext";
 import { PERSONAL_INFO } from "@/data/personal";
 import { useCountUp } from "@/hooks/useCountUp";
-import { STATS } from "@/lib/stats";
+import { proofBoardDotClass, proofBoardObservation } from "@/lib/proof-board";
+import { BAKED_STATS, STATS } from "@/lib/stats";
 import { compact, timeAgo } from "@/lib/terminal";
 import LiveTicker from "./LiveTicker";
 
@@ -16,15 +17,8 @@ import LiveTicker from "./LiveTicker";
  */
 export default function Hero() {
   const reduce = useReducedMotion();
-  const {
-    stats,
-    recent,
-    live,
-    loading,
-    setHighlight,
-    flashHighlight,
-    setSelected,
-  } = useWorkGraph();
+  const { stats, recent, live, setHighlight, flashHighlight, setSelected } =
+    useWorkGraph();
   const navigate = useNavigationStore((s) => s.navigateToSection);
 
   const rise = (delay: number, y = 14) =>
@@ -55,7 +49,12 @@ export default function Hero() {
     ? compact(stats.flagshipDownloads)
     : STATS.flagshipDownloads.display;
   const lastShip = recent[0];
-  const liveLabel = loading ? "loading" : live ? "live" : "cached";
+  const board = proofBoardObservation({
+    live,
+    stats,
+    bakedVerifiedAt: BAKED_STATS.verifiedAt,
+  });
+  const liveDot = board.freshness === "live";
 
   function jump(highlight: HighlightKind) {
     setSelected(null);
@@ -166,18 +165,29 @@ export default function Hero() {
           <div className="card w-full max-w-md overflow-hidden border-border/80 bg-surface/80 shadow-md backdrop-blur-xl">
             <div className="flex items-center justify-between border-b border-border-subtle px-4 py-2.5">
               <span className="font-mono text-[11px] text-text-tertiary">
-                live · from GitHub &amp; npm
+                from GitHub &amp; npm
               </span>
-              <span className="inline-flex items-center gap-1.5 font-mono text-[10.5px] text-text-tertiary">
+              <span
+                className="inline-flex items-center gap-1.5 font-mono text-[10.5px] text-text-tertiary"
+                data-freshness={board.freshness}
+                data-observed-at={board.observedAt ?? ""}
+              >
                 <span className="relative flex h-1.5 w-1.5">
-                  {live && (
+                  {liveDot && (
                     <span className="absolute inline-flex h-full w-full rounded-full bg-positive animate-ping-soft" />
                   )}
                   <span
-                    className={`relative inline-flex h-1.5 w-1.5 rounded-full ${live ? "bg-positive" : "bg-text-tertiary"}`}
+                    className={`relative inline-flex h-1.5 w-1.5 rounded-full ${proofBoardDotClass(board.freshness)}`}
                   />
                 </span>
-                {liveLabel}
+                {board.freshness}
+                {board.observedAt ? (
+                  <>
+                    {" "}
+                    ·{" "}
+                    <time dateTime={board.observedAt}>{board.observedAt}</time>
+                  </>
+                ) : null}
               </span>
             </div>
 

--- a/src/lib/proof-board.test.ts
+++ b/src/lib/proof-board.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from "bun:test";
+import {
+  normalizeObservationTime,
+  proofBoardDotClass,
+  proofBoardObservation,
+} from "./proof-board";
+import { BAKED_STATS } from "./stats";
+
+const BAKED = "2026-08-09T20:40:47.787Z";
+const LIVE_AT = "2026-08-22T12:00:00.000Z";
+const STALE_AT = "2026-08-21T08:15:30.500Z";
+
+describe("normalizeObservationTime", () => {
+  test("strips fractional seconds to UTC RFC3339", () => {
+    expect(normalizeObservationTime(BAKED)).toBe("2026-08-09T20:40:47Z");
+  });
+
+  test("returns null for missing or invalid input", () => {
+    expect(normalizeObservationTime(undefined)).toBeNull();
+    expect(normalizeObservationTime(null)).toBeNull();
+    expect(normalizeObservationTime("")).toBeNull();
+    expect(normalizeObservationTime("not-a-date")).toBeNull();
+  });
+});
+
+describe("proofBoardObservation", () => {
+  test("WorkGraph live=false never claims live even with a stats payload", () => {
+    const board = proofBoardObservation({
+      live: false,
+      stats: { updatedAt: LIVE_AT },
+      bakedVerifiedAt: BAKED,
+    });
+    expect(board.freshness).not.toBe("live");
+    expect(board.freshness).toBe("stale");
+    expect(board.observedAt).toBe("2026-08-22T12:00:00Z");
+  });
+
+  test("baked path when live=false and stats missing shows verifiedAt as stale", () => {
+    const board = proofBoardObservation({
+      live: false,
+      stats: null,
+      bakedVerifiedAt: BAKED,
+    });
+    expect(board.freshness).toBe("stale");
+    expect(board.observedAt).toBe("2026-08-09T20:40:47Z");
+  });
+
+  test("loading equivalent (live=false, no stats) does not use cached/live labels", () => {
+    const board = proofBoardObservation({
+      live: false,
+      stats: null,
+      bakedVerifiedAt: BAKED,
+    });
+    expect(["live", "cached", "loading"]).not.toContain(board.freshness);
+    expect(board.freshness).toBe("stale");
+  });
+
+  test("live fetch with observation time is live", () => {
+    const board = proofBoardObservation({
+      live: true,
+      stats: { updatedAt: LIVE_AT, freshness: "live", stale: false },
+      bakedVerifiedAt: BAKED,
+    });
+    expect(board.freshness).toBe("live");
+    expect(board.observedAt).toBe("2026-08-22T12:00:00Z");
+  });
+
+  test("successful /stats without freshness flag is live when WorkGraph is live", () => {
+    const board = proofBoardObservation({
+      live: true,
+      stats: { updatedAt: LIVE_AT },
+      bakedVerifiedAt: BAKED,
+    });
+    expect(board.freshness).toBe("live");
+    expect(board.observedAt).toBe("2026-08-22T12:00:00Z");
+  });
+
+  test("WorkGraph live with no stats uses baked verifiedAt as stale", () => {
+    const board = proofBoardObservation({
+      live: true,
+      stats: null,
+      bakedVerifiedAt: BAKED,
+    });
+    expect(board.freshness).toBe("stale");
+    expect(board.observedAt).toBe("2026-08-09T20:40:47Z");
+  });
+
+  test("API last-good stale payload is stale, not live", () => {
+    const board = proofBoardObservation({
+      live: true,
+      stats: { updatedAt: STALE_AT, stale: true, freshness: "stale" },
+      bakedVerifiedAt: BAKED,
+    });
+    expect(board.freshness).toBe("stale");
+    expect(board.observedAt).toBe("2026-08-21T08:15:30Z");
+  });
+
+  test("freshness=unavailable without a timestamp falls back to baked stale", () => {
+    const board = proofBoardObservation({
+      live: true,
+      stats: { freshness: "unavailable" },
+      bakedVerifiedAt: BAKED,
+    });
+    expect(board.freshness).toBe("stale");
+    expect(board.observedAt).toBe("2026-08-09T20:40:47Z");
+  });
+
+  test("live stats missing observation time cannot be called live", () => {
+    const board = proofBoardObservation({
+      live: true,
+      stats: { freshness: "live" },
+      bakedVerifiedAt: BAKED,
+    });
+    expect(board.freshness).toBe("stale");
+    expect(board.observedAt).toBe("2026-08-09T20:40:47Z");
+  });
+
+  test("no live graph and no baked verification is unavailable", () => {
+    const board = proofBoardObservation({
+      live: false,
+      stats: null,
+      bakedVerifiedAt: null,
+    });
+    expect(board.freshness).toBe("unavailable");
+    expect(board.observedAt).toBeNull();
+  });
+
+  test("freshness vocabulary is only live|stale|unavailable", () => {
+    const samples = [
+      proofBoardObservation({
+        live: false,
+        stats: null,
+        bakedVerifiedAt: BAKED,
+      }),
+      proofBoardObservation({
+        live: true,
+        stats: { updatedAt: LIVE_AT },
+        bakedVerifiedAt: BAKED,
+      }),
+      proofBoardObservation({ live: false, stats: null }),
+    ];
+    for (const board of samples) {
+      expect(["live", "stale", "unavailable"]).toContain(board.freshness);
+      expect(board.freshness).not.toBe("cached");
+      expect(board.freshness).not.toBe("loading");
+    }
+  });
+});
+
+describe("proofBoardDotClass", () => {
+  test("maps freshness to distinct instrument colours", () => {
+    expect(proofBoardDotClass("live")).toBe("bg-positive");
+    expect(proofBoardDotClass("stale")).toBe("bg-amber-400");
+    expect(proofBoardDotClass("unavailable")).toBe("bg-text-tertiary");
+  });
+});
+
+describe("shipped baked stats file", () => {
+  test("WorkGraph live=false surfaces stats-baked verifiedAt and never live", () => {
+    const board = proofBoardObservation({
+      live: false,
+      stats: null,
+      bakedVerifiedAt: BAKED_STATS.verifiedAt,
+    });
+    expect(board.freshness).toBe("stale");
+    expect(board.freshness).not.toBe("live");
+    expect(board.observedAt).toBe(
+      normalizeObservationTime(BAKED_STATS.verifiedAt),
+    );
+    expect(board.observedAt).toBeTruthy();
+  });
+});

--- a/src/lib/proof-board.ts
+++ b/src/lib/proof-board.ts
@@ -1,0 +1,77 @@
+/**
+ * Hero proof-board freshness — KYLE-INSTRUMENTS.
+ *
+ * Changing GitHub/npm figures on the hero board are instruments, not vanity.
+ * Baked or cached numbers may stay on screen, but they cannot be labelled live.
+ * Vocabulary is live | stale | unavailable, always with an observation time
+ * when a verified value is shown.
+ */
+export type ProofFreshness = "live" | "stale" | "unavailable";
+
+export interface ProofBoardStats {
+  updatedAt?: string;
+  stale?: boolean;
+  freshness?: string;
+}
+
+export interface ProofBoardInput {
+  /** WorkGraph `live`: true once at least one live fetch landed. */
+  live: boolean;
+  stats: ProofBoardStats | null;
+  bakedVerifiedAt?: string | null;
+}
+
+export interface ProofBoardObservation {
+  freshness: ProofFreshness;
+  observedAt: string | null;
+}
+
+const NON_LIVE_FRESHNESS = new Set(["stale", "unavailable", "not_observed"]);
+
+/** RFC3339 UTC without fractional seconds, or null if unparseable. */
+export function normalizeObservationTime(
+  iso: string | null | undefined,
+): string | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+function statsMayClaimLive(stats: ProofBoardStats): boolean {
+  if (stats.stale === true) return false;
+  if (stats.freshness && NON_LIVE_FRESHNESS.has(stats.freshness)) return false;
+  return Boolean(normalizeObservationTime(stats.updatedAt));
+}
+
+/**
+ * Derive the hero proof-board freshness label and observation time.
+ *
+ * Oracle: when WorkGraph `live` is false the board never claims live.
+ * The baked path is stale and surfaces `verifiedAt`.
+ */
+export function proofBoardObservation(
+  input: ProofBoardInput,
+): ProofBoardObservation {
+  const bakedAt = normalizeObservationTime(input.bakedVerifiedAt);
+  const statsAt = input.stats
+    ? normalizeObservationTime(input.stats.updatedAt)
+    : null;
+  const observedFallback = statsAt ?? bakedAt;
+
+  if (input.live && input.stats && statsMayClaimLive(input.stats)) {
+    return { freshness: "live", observedAt: statsAt };
+  }
+
+  if (observedFallback) {
+    return { freshness: "stale", observedAt: observedFallback };
+  }
+
+  return { freshness: "unavailable", observedAt: null };
+}
+
+export function proofBoardDotClass(freshness: ProofFreshness): string {
+  if (freshness === "live") return "bg-positive";
+  if (freshness === "stale") return "bg-amber-400";
+  return "bg-text-tertiary";
+}

--- a/src/lib/terminal.ts
+++ b/src/lib/terminal.ts
@@ -34,6 +34,10 @@ export interface TermStats {
   byOwner: Record<string, number>;
   repos: number;
   updatedAt: string;
+  /** True when the API served a previously verified snapshot. */
+  stale?: boolean;
+  /** `live` | `stale` | `unavailable` | `not_observed` when the API reports it. */
+  freshness?: string;
 }
 
 async function get<T>(path: string, signal?: AbortSignal): Promise<T> {


### PR DESCRIPTION
## Identity

`KYLE-INSTRUMENTS` — Honest live evidence instruments on `kylet.se` / `shtse8/portfolio-website`.

## Fate

`live`. Destination meaning unchanged. No dest-lock.

## Destination revision

`6b6f8ed68de2a16d4bc9903a7a28986c83295c60` (`docs/vision.md` / `docs/capabilities.md` on `origin/main`).

## Write/effect set

Hero proof board must not label baked or cached stats as live. It exposes `live | stale | unavailable` plus observation time.

- `src/components/Hero.tsx`
- `src/lib/proof-board.ts`
- `src/lib/proof-board.test.ts`
- `src/lib/terminal.ts` (optional `stale` / `freshness` on `TermStats`)

No API contract change, no docs dest edit, no lockfile, no land, no deploy.

## Oracle / evidence layer

Source candidate. Requested oracle:

- When WorkGraph `live=false` the board never claims live.
- Baked path shows `verifiedAt`.

Local evidence: `bunx biome check .`, `bunx tsc --noEmit`, `bun test` (30 pass), `bun scripts/check-cinematic-markers.mjs`, `bun run build`.

## Recovery path

Independent Worker judges this exact SHA. Accept → enqueue/land. Reject → repair this write-set; the repair SHA needs a fresh independent Worker. Do not merge from this Worker. Do not wait for CI. Do not treat a green check as live proof.

## Collision audit

Open PRs `#26` (CI runner) and Renovate lockfile PRs `#4` `#5` `#6` `#7` `#8` `#9` `#12` `#14` `#15` `#17` do not touch this write-set. This Worker did not take those PRs.

## Candidate

`bd4970124f5bd1befc5857fcc41022ceec761336`