### PR TITLE
docs(dest-lock): add canonical vision + capabilities

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -1,99 +1,24 @@
-# KYLE identity graph
+# kylet.se identity graph
 
-The destination is [`vision.md`](vision.md). This graph records durable
-identities, their fate, hard prerequisites, and falsifiable completion oracles
-for the `kylet.se` proof surface. It is not a roadmap, work queue,
-implementation inventory, current status report, or second product destination.
-Cite the `KYLE-*` IDs below. Fate is `live`, `dead`, or `rename-to:<ID>`. One
-colloquial name has one fate.
+**Status:** Identity registry. Not live proof.
+**Scope:** kylet.se — decision-proving portfolio site + live API.
+**Vision:** [`vision.md`](vision.md)
+**North Star:** [`NORTH_STAR.md`](NORTH_STAR.md)
+**Cite:** the **ID** column.
 
-## Authority boundary
+This file is the identity graph. It is not a PRD, ADR index, or live grade. Destination stays in [`vision.md`](vision.md). Field law stays in `api-rust`, `src/`, `sylphx.toml`, and the Gateway wire. If this file conflicts with those, this file is wrong.
 
-- This repository owns the static portfolio surface, evidence projections,
-  curated history, Rust live API, agent persona and tools, engagement journey,
-  and product acceptance.
-- GitHub and npm own their external facts. The Sylphx AI Gateway owns inference.
-  Sylphx Platform owns generic build, artifact, deployment, routing, secret, and
-  runtime infrastructure. Unavailability at one of those boundaries does not
-  authorize a repo-local substitute or fabricated success.
-- Source code and executable contracts own interface behavior. This graph owns
-  product identity decomposition, fate, and oracles only.
+```text
+ID | Identity | Fate | Depends on | Done when
+```
 
 ## Graph
 
-The table is the graph. The Mermaid picture names the same IDs and edges.
-
-```mermaid
-flowchart TB
-  PROMISE[KYLE-PROMISE]
-  GRAPH[KYLE-GRAPH]
-  INSTRUMENTS[KYLE-INSTRUMENTS]
-  ARCHIVE[KYLE-ARCHIVE]
-  AGENT[KYLE-AGENT]
-  ENGAGE[KYLE-ENGAGE]
-  SURFACE[KYLE-SURFACE]
-  DELIVERY[KYLE-DELIVERY]
-  PROOF[KYLE-PROOF]
-
-  GRAPH --> INSTRUMENTS
-  GRAPH --> ARCHIVE
-  GRAPH --> AGENT
-  INSTRUMENTS --> AGENT
-  PROMISE --> ENGAGE
-  GRAPH --> ENGAGE
-  PROMISE --> SURFACE
-  GRAPH --> SURFACE
-  INSTRUMENTS --> SURFACE
-  ARCHIVE --> SURFACE
-  AGENT --> SURFACE
-  ENGAGE --> SURFACE
-  SURFACE --> PROOF
-  DELIVERY --> PROOF
-```
-
-`KYLE-DELIVERY` is an independent prerequisite of the terminal proof. Product
-delivery mechanics can be established without pretending the customer journey
-is live; conversely, a reachable surface cannot bypass exact delivery identity.
-
-## Identity registry
-
 | ID | Identity | Fate | Depends on | Done when |
 | --- | --- | --- | --- | --- |
-| `KYLE-PROMISE` | Present identity and decision frame | live | — | A human or external agent reaching the primary static surface can accurately state that Kyle builds infrastructure AI agents run on, identify the intended hiring, partnership, OSS-adoption, collaboration, or craft decision, and reach evidence without first using chat. Company and historical material supports this person-level promise rather than becoming an equal product or a competing identity. |
-| `KYLE-GRAPH` | One current evidence graph | live | — | One product-owned semantic graph connects current work, capabilities, repositories, packages, adoption, activity, companies, and named claims for both human and machine projections. Each changing fact names its external authority and observation time; current facts, curated history, and unavailable values remain distinct. A parallel current-work catalog, frozen number in persona or copy, unexplained zero, or UI-only fact that can contradict the graph fails the node. |
-| `KYLE-INSTRUMENTS` | Honest live evidence instruments | live | `KYLE-GRAPH` | Stats, activity, project, repository, package-download, and structured-claim surfaces obtain changing facts from the named authority and expose provenance, observation time, and freshness consistently to humans and agents. A failed current read may serve only a previously verified, time-labelled stale value; without one it is unavailable. Cached or baked data, an empty provider response, route reachability, `/healthz`, or a successful fixture cannot be called live, and unsupported package identities cannot silently understate adoption. |
-| `KYLE-ARCHIVE` | Compressed shipped-era proof | live | `KYLE-GRAPH` | Historical games, social products, portals, enterprise work, and company eras remain inspectable with attributed media, outcomes, and real outlinks, while self-attested or time-bounded claims are visibly distinct from live GitHub or npm facts. The archive is secondary to present AI-infrastructure proof, uses the graph's vocabulary, and does not create another landing journey, content authority, or equal-weight company portal. |
-| `KYLE-AGENT` | Grounded portfolio representative | live | `KYLE-GRAPH`, `KYLE-INSTRUMENTS` | The sole agent stays within Kyle's public work and fit, uses the product tools before quoting changing facts, and produces a useful answer whose cited numbers agree with the current instrument observations. Secrets remain server-side, tool or Gateway failures cannot fall through to memory or a generic response, and unavailable credentials or upstream failures make the UI absent or explicitly unavailable without broken response theatre. Readiness or health proves only configuration reachability; live completion requires an actual production tool call and usable terminal answer, plus a failure probe that demonstrates fail-closed behavior. |
-| `KYLE-ENGAGE` | One visitor-owned next action | live | `KYLE-PROMISE`, `KYLE-GRAPH` | A visitor can contact, hire, partner, inspect, install, star, or contribute through one clear engagement system and real destination links. Agent-assisted email ends in a visitor-owned send, while direct email and relevant external links remain usable when dynamic evidence or chat is unavailable. No account, multi-field form, autonomous outreach, lead sale, or shadow CRM becomes a second conversion product. |
-| `KYLE-SURFACE` | Integrated human and machine proof surface | live | `KYLE-PROMISE`, `KYLE-GRAPH`, `KYLE-INSTRUMENTS`, `KYLE-ARCHIVE`, `KYLE-AGENT`, `KYLE-ENGAGE` | One domain and narrative spine compose Promise, Evidence, Agent, and Engage for a fast human skim, deeper inspection, and read-only external-agent retrieval. Static content remains useful before dynamic data or inference; live, stale, curated, and unavailable states are perceivable; the archive stays secondary; and no terminal, resume, blog, company portal, exhaustive repo dump, or second API/content authority competes with the proof loop. |
-| `KYLE-DELIVERY` | Exact product delivery acceptance | live | — | Every first-party required check for the exact candidate SHA runs on the owned `sylphx-linux-standard` profile with no GitHub-hosted, generic self-hosted, dynamic, or repo-specific fallback. The accepted source, check run, immutable web and API artifacts, desired production revision, and observed production revision reconcile to the same identity before product probes run. Source, candidate, landed, released, artifact, deployed, and live states remain distinct; a green check, cached export, preview, queued job, mutable tag, route response, `/healthz`, `/chat/ready`, commit SHA, or deploy light alone cannot close the node. |
-| `KYLE-PROOF` | Finished evidence-backed decision journey | live | `KYLE-SURFACE`, `KYLE-DELIVERY` | At one exact production artifact identity on `kylet.se`, a representative visitor can state the promise, verify a current claim against its named authority, distinguish live evidence from stale or curated evidence, inspect a relevant current-work or archive path, receive a grounded tool-using agent answer, and open the intended engagement route. The same promise and evidence are retrievable through the machine surface, and a separate unavailable-dependency observation proves fail-closed instruments and agent behavior while direct engagement remains usable. Source, CI, health, cached artifacts, preview reachability, or deployment state cannot substitute for this live customer observation. |
+| WEB-STATS | Live work-graph + stats data plane (SylphxAI/pdf-reader-mcp etc.) | live | — | `GET /stats` / `GET /projects` / `GET /activity` / `GET /downloads` via `api-rust` (sole live authority, single JSON REST contract ADR-169) return live-measured GitHub stars, npm downloads, repos, commits with `freshness=live` + `verifiedAt` honesty (stale-on-fail, never-fabricated zeros) at the live layer behind the `sylphx.toml` nginx BFF + api deploy; dual curated-catalog vs overlay content is retired to one authority. |
+| WEB-CHAT | Agent contact plane (Sylphx AI Gateway dogfood) | live | WEB-STATS | `POST /chat` (Rate: 12/3min, 60/day per IP) over Sylphx AI Gateway `POST /v1/responses` with persona + 5 tools (`list_projects`, `get_repo`, `recent_activity`, `search_projects`, `npm_downloads`) answers and deep-links at the live layer at `https://kylet.se` without `gateway 401 unsupported_credential`. |
+| WEB-SITE | One-page narrative site (least system) + navigation | live | WEB-STATS | Next.js static export `out/` single promise per visitor job completes `state → verify → act` (contact/hire/partner/star/install/deep-link) without a form at the live layer. |
+| WEB-LEGACY | Dual data-plane as product | dead | — | Prior dual Rust/TS wiring, inventoried 29-screenshot residual catalog, and `projects.ts` 2.3k-line dual content that invents a second browsing truth carry no live fate; `api-rust` single JSON contract is the writer. |
 
-## Evidence boundaries
-
-| Layer | Establishes | Does not establish |
-| --- | --- | --- |
-| Source | The exact candidate content, contracts, workflow selectors, and tests | A passing check, built artifact, deployment, or customer outcome |
-| Check | The declared validations ran for the exact source on the required owned runner | The immutable artifact that was deployed or any production behavior |
-| Artifact and deploy | Exact immutable web/API artifacts were produced and the production owner observed that revision | Fresh external evidence, a usable agent answer, or a completed visitor decision |
-| Live | The named postcondition was observed through the exact production identity, including provenance/freshness and failure behavior | Future availability or facts outside the observed scope and time |
-
-## Reading rules
-
-1. `Depends on` is a hard edge, not preferred sequence. Independent nodes may
-   proceed in parallel when their write and effect sets do not collide.
-2. `Fate` is `live`, `dead`, or `rename-to:<ID>`. Writing a fate and executing
-   the named object are separate write/effect sets.
-3. `Done when` is a destination oracle, not a statement about this checkout,
-   an open pull request, CI, or production.
-4. Cached, baked, stale, curated, and live evidence are distinct. A labelled
-   fallback may preserve usefulness but cannot close a live clause.
-5. Health and readiness endpoints prove only their named narrow condition. A
-   live instrument requires current authority readback; a live agent requires a
-   grounded terminal response; the finished product requires the visitor
-   journey at an exact deployed identity.
-6. The owned-runner hard cut is part of `KYLE-DELIVERY`. External runner or
-   Platform unavailability blocks only the affected check or delivery claim and
-   never authorizes a fallback selector or fabricated proof.
-7. Current work, PR collisions, checks, deploy state, and live incidents belong
-   to the forge and their runtime owners, not this graph.
+Edges are hard prerequisites. A preview build on Pages or a `200` on the edge without live `freshness=live` and a green chat turn does not close a node.

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,166 +1,29 @@
-# kylet.se product vision
+# kylet.se Vision
 
-This is the canonical destination for `shtse8/portfolio-website`. Identities,
-fates, dependencies, and oracles live in [`capabilities.md`](capabilities.md);
-interfaces and technical choices remain owned by code, tests, and the accepted
-ADRs. This file contains no current work or delivery claim. The finished
-product identity is `KYLE-PROOF`.
+**Status:** Canonical product destination
+**Identity graph:** [`capabilities.md`](capabilities.md)
+**North Star package:** [`docs/NORTH_STAR.md`](NORTH_STAR.md) (2026-08-10, vision-design; no backward-compat obligation)
+
+This document owns the long-term product destination. It does not claim the destination is landed or live. Source, checks, artifacts, deployment, readiness, customer behavior, and soak remain separate evidence layers.
 
 ## Destination
 
-**kylet.se is the most trustworthy, least-noisy proof surface for Kyle Tse, an
-AI infrastructure builder, where humans and agents decide and engage against
-evidence they can verify.**
+kylet.se (`https://kylet.se`) is the decision-proving portfolio of Kyle Tse — the site is the proof, not a brochure about proof — where a decision-maker (recruiter/hiring eng, founder/partner, OSS adopter, collaborator) with one job ("Is this the right person/stack/builder for X?") can, within one short session, **state, verify, and act**: state one repeatable promise, verify every material claim via live-measured / stale-labeled / absent honesty ladder, and act (contact, hire, partner, star, install, deep-link into real work) without a form or new mental model.
 
-A visitor should leave one short session able to:
+The promise is delivered by the **least system**: the fewest concepts, surfaces, services, and copy that still produce those three outcomes for every primary visitor job. The Rust `api-rust` is the sole live data-plane authority (single JSON REST contract: `GET /healthz`, `GET /stats`, `GET /activity`, `GET /projects`, `GET /recent`, `GET /repo`, `GET /downloads`, `POST /chat` via Sylphx AI Gateway `POST /v1/responses`); the site itself is the dogfood of the builder's AI stack (live stats/activity + agent contact plane).
 
-1. state Kyle's present identity accurately;
-2. verify the work, adoption, and shipping history material to their decision;
-   and
-3. take the relevant next action without a new account, a form, or a second
-   mental model.
+## Users and their jobs
 
-The site earns trust by being the proof, not by decorating unsupported claims.
-Its deepest concept is one integrated loop: **Promise · Evidence · Agent ·
-Engage**.
+- **Decision-makers** who need one short session to answer "right person/stack/builder for X" and act on it.
+- **OSS adopters** who need to verify stars/downloads/repos and deep-link to the real flagged repo.
 
-## People and decisions
+## Not doing
 
-| Visitor | Decision the product helps finish |
-| --- | --- |
-| Hiring engineer or staff-level recruiter | Whether Kyle is credible for AI infrastructure, platform, MCP, or founder-engineer work and worth contacting |
-| Founder, partner, or client | Whether Kyle is the right technical builder or integration partner for the opportunity |
-| OSS adopter or agent builder | Whether a named project is relevant and worth inspecting, installing, starring, or contributing to |
-| Peer engineer | Whether the public work and the site itself demonstrate trustworthy engineering craft |
-| External agent, search system, or RAG client | Whether it can retrieve a stable, source-labelled representation of Kyle and his work |
-
-Product and company sites remain the homes for their own offers. kylet.se owns
-the person-level decision across Kyle's current work and shipped eras.
-
-## Product shape
-
-### Promise
-
-The first surface communicates one repeatable present-tense identity: Kyle
-builds the infrastructure AI agents run on. Availability, location, flagship
-work, and the path into evidence support that promise; an exhaustive biography
-does not compete with it.
-
-### Evidence
-
-One evidence graph connects present work, capabilities, adoption, activity,
-companies, and shipped eras. Human views and machine-readable views project the
-same facts. Current GitHub and npm facts can be live instruments; historical
-career outcomes are curated, attributed evidence and never wear a live badge.
-
-The present is primary. Historical games, social products, portals, and
-enterprise work remain available as compressed credibility in one archive,
-without turning the first journey into a museum or creating another content
-authority. Outlinks lead to the real repository, package, company, or product
-home.
-
-### Agent
-
-One constrained representative helps a visitor interrogate the same evidence
-graph and judge fit. It speaks about Kyle, stays within Kyle's public work and
-experience, uses product-owned tools before quoting changing facts, exposes
-useful evidence of those tool calls, and never becomes a general assistant.
-
-The agent is a real capability only when a production request returns a
-grounded, usable answer. Readiness, a health response, a configured host, or a
-successful cached answer is not a substitute. When credentials, tools, the AI
-Gateway, or evidence are unavailable, the agent fails closed and the product
-does not present invented facts or broken AI theatre.
-
-### Engage
-
-Contact, hire, partner, adopt, inspect, and contribute are outcomes of the same
-proof loop. The product offers one clear engagement path with direct email and
-real destination links as durable escapes. The agent may draft a useful email,
-but the visitor owns the send and can still engage when the agent is
-unavailable.
-
-There is no account, multi-field lead form, autonomous outreach, or shadow CRM.
-
-## Experience and public surface
-
-- One domain and one narrative spine serve both a fast human skim and deeper
-  evidence inspection.
-- The static surface remains readable, navigable, accessible, and useful
-  without waiting for dynamic instruments or agent inference.
-- Dynamic stats, activity, repository, package, and claim views are instruments
-  over the evidence graph, not vanity counters.
-- A curl-friendly, read-only identity and evidence surface lets external agents
-  verify the same public facts without scraping visual chrome.
-- The static web remains presentation. One Rust service owns live evidence and
-  chat contracts; the Sylphx AI Gateway owns inference and Sylphx Platform owns
-  generic deployment infrastructure.
-- The portfolio remains a personal proof surface, not a holding-company portal
-  or a substitute product site for Sylphx, Epiow, Cubeage, or another company.
-
-## Truth contract
-
-Every material changing claim carries enough provenance and time information
-for a visitor to distinguish these states:
-
-| State | Meaning |
-| --- | --- |
-| Live | The named authority was successfully observed for this response or production interaction, with an observation time |
-| Stale | A previously verified observation is shown with its verification time because a current read failed |
-| Curated | A stable or historical claim names its source or self-attested status and is not styled as a live measurement |
-| Unavailable | Neither a current observation nor a valid labelled fallback exists, so the value or capability is absent or explicitly unavailable |
-
-A baked file, cache entry, last-known-good record, fixture, source test, green
-check, preview, route response, health endpoint, readiness endpoint, commit SHA,
-or deploy record proves only its own layer. None may be relabelled as a live
-customer outcome. Zero, an empty collection, or a generic agent response may
-not stand in for unknown data.
-
-Correctness and Security are the non-tradeable floors: hide or disable a false
-instrument or unavailable agent before training the visitor to distrust the
-whole proof surface.
-
-## North Star Metric
-
-No validated customer-value metric is declared for kylet.se. The product vision
-and `KYLE-PROOF` oracle express the desired decision outcome, but neither
-authorizes visitor telemetry nor turns a proxy into proof of that outcome.
-
-Proof-item inspection and outbound engagement are input observations only; they
-do not establish a completed visitor decision. Page views, API calls, agent
-opens, health probes, and clicks remain activity unless an accepted measurement
-contract separately defines outcome validation, privacy and retention
-authority, and the corresponding product capability ownership.
-
-## Boundaries and non-goals
-
-The product does not become:
-
-- a blog or CMS required to understand Kyle;
-- a parallel terminal, resume, company portal, or product-marketing site;
-- an exhaustive repository dump or a set of equal-weight company brands;
-- a general-purpose assistant, multi-persona chat product, or visitor account
-  system;
-- a paid tier, advertising surface, affiliate funnel, or lead-selling system;
-- a browser credential holder, TypeScript backend authority, or second API
-  contract;
-- a public write API, autonomous outbound system, or ungoverned chat-log growth
-  database; or
-- a second current-work inventory beside the evidence graph, or a third content
-  authority beside the graph and curated archive.
+- A second Rust/TS dual data-plane or dual content authority (curated catalog vs live GitHub overlay must be reconciled — `api-rust` is the authority).
+- Visual density or feature-count "AI-native" chrome as power; invented marketing fog for verification.
 
 ## Product oracle
 
-At one exact production artifact identity on `kylet.se`, a representative
-visitor can state the promise, verify a current claim against its named external
-authority, distinguish live evidence from stale or curated evidence, inspect a
-relevant work or era path, obtain a grounded tool-using agent answer, and open
-the intended engagement route. A separate failure observation proves that
-unavailable evidence and agent dependencies fail closed while direct engagement
-still works.
+The destination is true only when a first-time visitor at `https://kylet.se` can, in one short live session, state the one promise, verify live GitHub stars/npm downloads/repos/activity via `api-rust` (`freshness=live`, `verifiedAt` honesty ladder, never-fabricated zeros), and successfully `POST /chat` a message that reaches Sylphx AI Gateway and returns an answer grounded in the 5 tools without `401 unsupported_credential`, at the live layer via the `sylphx.toml` nginx BFF + api deployment.
 
-The same promise and evidence remain retrievable through the public
-machine-readable surface. The result is not established by source, CI, an
-artifact, a health response, cached data, a preview, or a deploy signal without
-that exact live journey. The live identity is `KYLE-PROOF` in
-[`capabilities.md`](capabilities.md).
+A static export (`out/`) build or `GET /healthz` on preview is not the live-chat-and-verify oracle. The broken `POST /chat` gateway credential boundary captured 2026-08-10 is the outstanding false for this oracle.


### PR DESCRIPTION
Owner dest-lock per `standards/docs.md` §2–3.

- `docs/vision.md` owns product destination (what finished product exists, for whom, not doing, oracle)
- `docs/capabilities.md` owns identity graph `ID | Identity | Fate | Depends on | Done when`

Closes frontier `False/Unknown` that blocked shared-meaning locks and fan-out per `RECONCILE.md`.

This branch is `owner/docs-dest-lock-20260823` from `origin/main`. No source contract change.
Review: confirm destination = north-star ambition at claimed layer, fate = live/dead per portfolio, Depends/ Done-when are truth prerequisites with falsifiable oracles.
