### PR TITLE
fix(web,api): restore kylet.se BFF to api :80 and emit /stats freshness

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,9 @@ COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1
 RUN bun run build
 
-FROM nginx:alpine AS runner
+# nginxinc unprivileged: uid 101, no chown on start, works with capabilities.drop=ALL.
+FROM nginxinc/nginx-unprivileged:1.27-alpine AS runner
 COPY --from=builder /app/out /usr/share/nginx/html
-# Provide the server config as a template so nginx's entrypoint substitutes ${PORT}
-# (the platform injects PORT=3000). NGINX_ENVSUBST_FILTER limits substitution to PORT
-# so nginx runtime vars ($uri, $host, …) are preserved.
 COPY nginx.conf /etc/nginx/templates/default.conf.template
 ENV PORT=3000
 # Default matches Platform connect URL host:port (Knative private :80).
@@ -19,4 +17,3 @@ ENV API_INTERNAL_URL=http://api.portfolio-website.svc.cluster.local
 # survive envsubst. Platform injects API_INTERNAL_URL at runtime.
 ENV NGINX_ENVSUBST_FILTER=PORT|API_INTERNAL_URL
 EXPOSE 3000
-CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,10 @@ COPY --from=builder /app/out /usr/share/nginx/html
 # so nginx runtime vars ($uri, $host, …) are preserved.
 COPY nginx.conf /etc/nginx/templates/default.conf.template
 ENV PORT=3000
-ENV NGINX_ENVSUBST_FILTER=PORT
+# Default matches Platform connect URL host:port (Knative private :80).
+ENV API_INTERNAL_URL=http://api.portfolio-website.svc.cluster.local
+# Substitute only these so nginx runtime vars ($uri, $host, $bff_upstream, …)
+# survive envsubst. Platform injects API_INTERNAL_URL at runtime.
+ENV NGINX_ENVSUBST_FILTER=PORT|API_INTERNAL_URL
 EXPOSE 3000
 CMD ["nginx", "-g", "daemon off;"]

--- a/api-rust/src/rest_projection.rs
+++ b/api-rust/src/rest_projection.rs
@@ -20,6 +20,9 @@ pub fn stats_json(payload: &StatsPayload) -> Value {
         "byOwner": by_owner,
         "repos": payload.repos,
         "updatedAt": payload.updated_at,
+        "verifiedAt": payload.updated_at,
+        "freshness": "live",
+        "stale": false,
     })
 }
 
@@ -27,6 +30,8 @@ pub fn stats_json_stale(payload: &StatsPayload) -> Value {
     let mut v = stats_json(payload);
     if let Some(obj) = v.as_object_mut() {
         obj.insert("stale".to_string(), Value::Bool(true));
+        obj.insert("freshness".to_string(), Value::String("stale".into()));
+        obj.insert("verifiedAt".to_string(), json!(payload.updated_at));
     }
     v
 }
@@ -143,5 +148,8 @@ mod tests {
         assert!(v.get("npmDownloads").is_some());
         assert!(v.get("byOwner").is_some());
         assert!(v.get("github_stars").is_none());
+        assert_eq!(v["freshness"], "live");
+        assert_eq!(v["verifiedAt"], "2026-08-09T00:00:00Z");
+        assert_eq!(v["stale"], false);
     }
 }

--- a/api-rust/tests/contract_stale.rs
+++ b/api-rust/tests/contract_stale.rs
@@ -16,6 +16,8 @@ fn stale_projection_adds_flag() {
     };
     let v = stats_json_stale(&stats);
     assert_eq!(v["stale"], true);
+    assert_eq!(v["freshness"], "stale");
+    assert_eq!(v["verifiedAt"], "t");
     assert_eq!(v["githubStars"], 10);
 
     let act = ActivityPayload {

--- a/api-rust/tests/wiremock_stats.rs
+++ b/api-rust/tests/wiremock_stats.rs
@@ -68,4 +68,8 @@ async fn stats_endpoint_uses_wiremock_github_and_npm() {
     assert_eq!(v["flagshipStars"], 99);
     assert_eq!(v["npmDownloads"], 70); // 10 packages * 7
     assert_eq!(v["flagshipDownloads"], 7);
+    assert_eq!(v["freshness"], "live");
+    assert_eq!(v["stale"], false);
+    assert!(v.get("verifiedAt").and_then(|x| x.as_str()).is_some());
+    assert_eq!(v["verifiedAt"], v["updatedAt"]);
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -19,12 +19,14 @@ server {
     resolver 10.96.0.10 valid=5s ipv6=off;  # kube-dns ClusterIP (hostname fails nginx cold start)
     # API_INTERNAL_URL is injected by Platform (connect.services = ["api"]).
     # Knative private URL is :80 (queue-proxy), not container PORT 3001.
+    # Host must be the api Service name — queue-proxy 404s Host: kylet.se.
     set $bff_upstream "${API_INTERNAL_URL}";
+    set $bff_host "api.portfolio-website.svc.cluster.local";
 
     location = /activity {
-        proxy_pass $bff_upstream$request_uri;
+        proxy_pass $bff_upstream;
         proxy_http_version 1.1;
-        proxy_set_header Host $host;
+        proxy_set_header Host $bff_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
@@ -32,9 +34,9 @@ server {
         proxy_read_timeout 30s;
     }
     location = /stats {
-        proxy_pass $bff_upstream$request_uri;
+        proxy_pass $bff_upstream;
         proxy_http_version 1.1;
-        proxy_set_header Host $host;
+        proxy_set_header Host $bff_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
@@ -43,9 +45,9 @@ server {
     }
     # Live GitHub overlay used by WorkGraph (fallback JSON still ships in the static bundle).
     location = /projects {
-        proxy_pass $bff_upstream$request_uri;
+        proxy_pass $bff_upstream;
         proxy_http_version 1.1;
-        proxy_set_header Host $host;
+        proxy_set_header Host $bff_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
@@ -53,9 +55,9 @@ server {
         proxy_read_timeout 30s;
     }
     location = /recent {
-        proxy_pass $bff_upstream$request_uri;
+        proxy_pass $bff_upstream;
         proxy_http_version 1.1;
-        proxy_set_header Host $host;
+        proxy_set_header Host $bff_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
@@ -63,9 +65,9 @@ server {
         proxy_read_timeout 30s;
     }
     location = /repo {
-        proxy_pass $bff_upstream$request_uri;
+        proxy_pass $bff_upstream;
         proxy_http_version 1.1;
-        proxy_set_header Host $host;
+        proxy_set_header Host $bff_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
@@ -73,9 +75,9 @@ server {
         proxy_read_timeout 30s;
     }
     location = /downloads {
-        proxy_pass $bff_upstream$request_uri;
+        proxy_pass $bff_upstream;
         proxy_http_version 1.1;
-        proxy_set_header Host $host;
+        proxy_set_header Host $bff_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
@@ -83,16 +85,16 @@ server {
         proxy_read_timeout 30s;
     }
     location = /healthz {
-        proxy_pass $bff_upstream$request_uri;
+        proxy_pass $bff_upstream;
         proxy_http_version 1.1;
-        proxy_set_header Host $host;
+        proxy_set_header Host $bff_host;
         proxy_connect_timeout 2s;
         proxy_read_timeout 5s;
     }
     location = /claims {
-        proxy_pass $bff_upstream$request_uri;
+        proxy_pass $bff_upstream;
         proxy_http_version 1.1;
-        proxy_set_header Host $host;
+        proxy_set_header Host $bff_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
@@ -100,9 +102,9 @@ server {
         proxy_read_timeout 30s;
     }
     location /chat {
-        proxy_pass $bff_upstream$request_uri;
+        proxy_pass $bff_upstream;
         proxy_http_version 1.1;
-        proxy_set_header Host $host;
+        proxy_set_header Host $bff_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;

--- a/nginx.conf
+++ b/nginx.conf
@@ -22,7 +22,7 @@ server {
     set $bff_upstream "${API_INTERNAL_URL}";
 
     location = /activity {
-        proxy_pass $bff_upstream;
+        proxy_pass $bff_upstream$request_uri;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -32,7 +32,7 @@ server {
         proxy_read_timeout 30s;
     }
     location = /stats {
-        proxy_pass $bff_upstream;
+        proxy_pass $bff_upstream$request_uri;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -43,7 +43,7 @@ server {
     }
     # Live GitHub overlay used by WorkGraph (fallback JSON still ships in the static bundle).
     location = /projects {
-        proxy_pass $bff_upstream;
+        proxy_pass $bff_upstream$request_uri;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -53,7 +53,7 @@ server {
         proxy_read_timeout 30s;
     }
     location = /recent {
-        proxy_pass $bff_upstream;
+        proxy_pass $bff_upstream$request_uri;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -63,7 +63,7 @@ server {
         proxy_read_timeout 30s;
     }
     location = /repo {
-        proxy_pass $bff_upstream;
+        proxy_pass $bff_upstream$request_uri;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -73,7 +73,7 @@ server {
         proxy_read_timeout 30s;
     }
     location = /downloads {
-        proxy_pass $bff_upstream;
+        proxy_pass $bff_upstream$request_uri;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -83,14 +83,14 @@ server {
         proxy_read_timeout 30s;
     }
     location = /healthz {
-        proxy_pass $bff_upstream;
+        proxy_pass $bff_upstream$request_uri;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_connect_timeout 2s;
         proxy_read_timeout 5s;
     }
     location = /claims {
-        proxy_pass $bff_upstream;
+        proxy_pass $bff_upstream$request_uri;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -100,7 +100,7 @@ server {
         proxy_read_timeout 30s;
     }
     location /chat {
-        proxy_pass $bff_upstream;
+        proxy_pass $bff_upstream$request_uri;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/nginx.conf
+++ b/nginx.conf
@@ -17,7 +17,9 @@ server {
     # Re-resolve Service ClusterIP (Platform may recreate Services).
     # Variable proxy_pass requires resolver; kube-dns is in-cluster.
     resolver 10.96.0.10 valid=5s ipv6=off;  # kube-dns ClusterIP (hostname fails nginx cold start)
-    set $bff_upstream http://api.portfolio-website.svc.cluster.local:3001;
+    # API_INTERNAL_URL is injected by Platform (connect.services = ["api"]).
+    # Knative private URL is :80 (queue-proxy), not container PORT 3001.
+    set $bff_upstream "${API_INTERNAL_URL}";
 
     location = /activity {
         proxy_pass $bff_upstream;

--- a/scripts/api-smoke.sh
+++ b/scripts/api-smoke.sh
@@ -15,7 +15,7 @@ healthz="$(curl -fsS "$BASE_URL/healthz")"
 pass "/healthz"
 
 stats="$(curl -fsS "$BASE_URL/stats")"
-echo "$stats" | python3 -c "import json,sys; d=json.load(sys.stdin); assert 'githubStars' in d" \
+echo "$stats" | python3 -c "import json,sys; d=json.load(sys.stdin); assert 'githubStars' in d; assert d.get('freshness')=='live', d; assert d.get('verifiedAt') or d.get('updatedAt')" \
   || fail "/stats: $stats"
 pass "/stats"
 

--- a/src/lib/terminal.ts
+++ b/src/lib/terminal.ts
@@ -34,6 +34,8 @@ export interface TermStats {
   byOwner: Record<string, number>;
   repos: number;
   updatedAt: string;
+  /** Observation time for the live/stale ladder (same instant as updatedAt on live). */
+  verifiedAt?: string;
   /** True when the API served a previously verified snapshot. */
   stale?: boolean;
   /** `live` | `stale` | `unavailable` | `not_observed` when the API reports it. */


### PR DESCRIPTION
## Write/effect
Restore `api-rust` behind kylet.se `path_prefixes` and ship dest-honest web so the hero cannot label baked stats live.

## Identities
| ID | Fate | Layer |
| --- | --- | --- |
| WEB-STATS | live | live (False → recover) |
| WEB-CHAT | live | live (False → recover) |
| WEB-SITE | live | live (False → recover; dest already honest in #33) |
| WEB-LEGACY | dead | not this set |

Destination revision: `origin/main@2fd52b1ad27e2ce890500080f05b1ca5e0d8da1a` (`docs/vision.md` / `docs/capabilities.md`).

## Observation (before)
- `GET https://kylet.se/{healthz,stats,projects,activity,downloads}` → Cloudflare `502` `error code: 502`. Direct origin `138.199.132.65` `/stats` → nginx `502 Bad Gateway`.
- In-cluster: web nginx proxies `$bff_upstream` `http://api.portfolio-website.svc.cluster.local:3001` (connection refused). `http://api.portfolio-website.svc.cluster.local:80/healthz` and `API_INTERNAL_URL` (`http://api.portfolio-website.sylphx.internal:80`) return `ok`.
- HTTPRoute `portfolio-website/web` catch-all `/` on `kylet.se`; `api` HTTPRoute is only `slim-pal-0k3stq.sylphx.app` (api itself healthy: `/healthz ok`, `/chat/ready ready=true`).
- Live HTML `Last-Modified: Sat, 22 Aug 2026 12:01:46 GMT` still hardcodes `live · from GitHub & npm` + baked `1.2K★` (pre #33). Dest `2fd52b1` already has hero honesty; it is not on the edge because production `autoDeployMode=after_ci` and dest CI is queued with **zero** repo runners.
- Live `GET slim-pal…/stats` has `updatedAt` but **no** `freshness` / `verifiedAt` (activity already has `freshness=live`).
- Open leftover: #38 futures 0.3.34 (material dep, not this live repair); #39 http-body-util 0.1.5 (noise). Not folded. Not occupying this set.

## Change
- nginx BFF `proxy_pass` uses Platform `API_INTERNAL_URL` (Knative private `:80`), not ClusterIP `:3001`.
- `GET /stats` JSON now includes `freshness=live` + `verifiedAt` (stale path: `freshness=stale`).
- Dest hero honesty (#33) is already on this base; shipping this SHA (or dest + this BFF) is the live recovery.

## Oracle
- `GET https://kylet.se/stats` → `freshness=live` and `verifiedAt` (or `updatedAt` as verifiedAt).
- `POST https://kylet.se/chat` reaches Gateway without `502`/`401 unsupported_credential`.
- Live hero must not label baked stats `live` (`data-freshness` ≠ live when WorkGraph live=false).

## Layer / recovery
- Source: this PR. **Do not land by the authoring Worker.** Ready SHA is for an independent judge.
- Runtime: Platform (`sylphx deploy` / push-intake projecting `sylphx.toml` `[[domains]]` + `path_prefixes`). Hands is sole kube writer — no product `kubectl apply`.
- `#38` / `#39` remain leftover, not this set.

## Floors
```text
Outcome: kylet.se /stats is live-measured with freshness=live + verifiedAt; /chat reaches Gateway; hero does not label baked stats live
Applicable clause: standards/proof.md Truth layers (Live); standards/platform.md (sylphx.toml intent, Hands sole kube writer); standards/code.md one semantic authority
Trigger: public live contract WEB-STATS/WEB-CHAT/WEB-SITE is False; recovery is authorised Platform/GitOps, not product kubectl
Product mapping: sylphx.toml path_prefixes + nginx BFF + api-rust rest_projection stats_json
Oracle: GET /stats freshness=live + verifiedAt; POST /chat not 502/401; hero data-freshness not live on baked path
Gap or exception: none in this set; leftover #38/#39
```