### PR TITLE
fix(web): BFF to api ksvc :80, ignore Platform :3001 URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: No TS backend authority (sole Rust API)
         run: bash scripts/check-no-ts-backend.sh
 
+      - name: BFF upstream is api ksvc :80 (not Platform :3001)
+        run: bash scripts/check-bff-upstream.sh
+
       - name: Design markers gate
         run: bun scripts/check-cinematic-markers.mjs
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,7 @@ FROM nginxinc/nginx-unprivileged:1.27-alpine AS runner
 COPY --from=builder /app/out /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/templates/default.conf.template
 ENV PORT=3000
-# Default matches Platform connect URL host:port (Knative private :80).
-ENV API_INTERNAL_URL=http://api.portfolio-website.svc.cluster.local
-# Substitute only these so nginx runtime vars ($uri, $host, $bff_upstream, …)
-# survive envsubst. Platform injects API_INTERNAL_URL at runtime.
-ENV NGINX_ENVSUBST_FILTER=PORT|API_INTERNAL_URL
+# BFF upstream is hardcoded to the api ksvc :80 in nginx.conf. Do not
+# envsubst Platform API_INTERNAL_URL (:3001 container port) into proxy_pass.
+ENV NGINX_ENVSUBST_FILTER=PORT
 EXPOSE 3000

--- a/nginx.conf
+++ b/nginx.conf
@@ -17,14 +17,15 @@ server {
     # Re-resolve Service ClusterIP (Platform may recreate Services).
     # Variable proxy_pass requires resolver; kube-dns is in-cluster.
     resolver 10.96.0.10 valid=5s ipv6=off;  # kube-dns ClusterIP (hostname fails nginx cold start)
-    # API_INTERNAL_URL is injected by Platform (connect.services = ["api"]).
-    # Knative private URL is :80 (queue-proxy), not container PORT 3001.
-    # Host must be the api Service name — queue-proxy 404s Host: kylet.se.
-    set $bff_upstream "${API_INTERNAL_URL}";
+    # Platform injects API_INTERNAL_URL as http://host:3001 (container PORT).
+    # Knative ksvc / queue-proxy answers on :80; :3001 is connection-refused.
+    # Do not envsubst that URL into proxy_pass. Host must be the api Service
+    # name — queue-proxy 404s Host: kylet.se.
     set $bff_host "api.portfolio-website.svc.cluster.local";
+    set $bff_upstream "http://api.portfolio-website.svc.cluster.local";
 
     location = /activity {
-        proxy_pass $bff_upstream;
+        proxy_pass $bff_upstream$request_uri;
         proxy_http_version 1.1;
         proxy_set_header Host $bff_host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -34,7 +35,7 @@ server {
         proxy_read_timeout 30s;
     }
     location = /stats {
-        proxy_pass $bff_upstream;
+        proxy_pass $bff_upstream$request_uri;
         proxy_http_version 1.1;
         proxy_set_header Host $bff_host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -45,7 +46,7 @@ server {
     }
     # Live GitHub overlay used by WorkGraph (fallback JSON still ships in the static bundle).
     location = /projects {
-        proxy_pass $bff_upstream;
+        proxy_pass $bff_upstream$request_uri;
         proxy_http_version 1.1;
         proxy_set_header Host $bff_host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -55,7 +56,7 @@ server {
         proxy_read_timeout 30s;
     }
     location = /recent {
-        proxy_pass $bff_upstream;
+        proxy_pass $bff_upstream$request_uri;
         proxy_http_version 1.1;
         proxy_set_header Host $bff_host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -65,7 +66,7 @@ server {
         proxy_read_timeout 30s;
     }
     location = /repo {
-        proxy_pass $bff_upstream;
+        proxy_pass $bff_upstream$request_uri;
         proxy_http_version 1.1;
         proxy_set_header Host $bff_host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -75,7 +76,7 @@ server {
         proxy_read_timeout 30s;
     }
     location = /downloads {
-        proxy_pass $bff_upstream;
+        proxy_pass $bff_upstream$request_uri;
         proxy_http_version 1.1;
         proxy_set_header Host $bff_host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -85,14 +86,14 @@ server {
         proxy_read_timeout 30s;
     }
     location = /healthz {
-        proxy_pass $bff_upstream;
+        proxy_pass $bff_upstream$request_uri;
         proxy_http_version 1.1;
         proxy_set_header Host $bff_host;
         proxy_connect_timeout 2s;
         proxy_read_timeout 5s;
     }
     location = /claims {
-        proxy_pass $bff_upstream;
+        proxy_pass $bff_upstream$request_uri;
         proxy_http_version 1.1;
         proxy_set_header Host $bff_host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -102,7 +103,7 @@ server {
         proxy_read_timeout 30s;
     }
     location /chat {
-        proxy_pass $bff_upstream;
+        proxy_pass $bff_upstream$request_uri;
         proxy_http_version 1.1;
         proxy_set_header Host $bff_host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/scripts/check-bff-upstream.sh
+++ b/scripts/check-bff-upstream.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# WEB-STATS BFF: Platform injects API_INTERNAL_URL as :3001 (container PORT).
+# Knative queue-proxy is :80. Rendered nginx must not proxy to :3001.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONF="${ROOT}/nginx.conf"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+[[ -f "$CONF" ]] || fail "nginx.conf missing"
+
+if grep -q '\${API_INTERNAL_URL}' "$CONF"; then
+  fail "nginx.conf must not envsubst API_INTERNAL_URL (Platform sets :3001)"
+fi
+
+python3 - "$CONF" <<'PY'
+import re, sys
+from pathlib import Path
+
+src = Path(sys.argv[1]).read_text()
+injected = "http://api.portfolio-website.sylphx.internal:3001"
+rendered = src.replace("${PORT}", "3000").replace("${API_INTERNAL_URL}", injected)
+
+upstream = re.search(r'set \$bff_upstream\s+"([^"]+)";', rendered)
+if not upstream:
+    sys.exit("FAIL: $bff_upstream is missing")
+if ":3001" in upstream.group(1) or injected in upstream.group(1):
+    sys.exit(f"FAIL: $bff_upstream uses container port: {upstream.group(1)}")
+if upstream.group(1) != "http://api.portfolio-website.svc.cluster.local":
+    sys.exit(f"FAIL: $bff_upstream is not the api ksvc on implied :80: {upstream.group(1)}")
+
+passes = re.findall(r"(?m)^\s*proxy_pass\s+([^;]+);", rendered)
+if not passes:
+    sys.exit("FAIL: no proxy_pass directives")
+bad = [p for p in passes if p.strip() != "$bff_upstream$request_uri"]
+if bad:
+    sys.exit(f"FAIL: proxy_pass must keep request URI; got {bad}")
+
+print("check-bff-upstream: PASS — BFF upstream is ksvc :80; :3001 injection cannot become proxy_pass")
+PY


### PR DESCRIPTION
## Write/effect
Restore kylet.se nginx BFF so `api-rust` stats/verify/act paths are not 502.

## Identities
| ID | Fate | Layer |
| --- | --- | --- |
| WEB-STATS | live | live (False → recover) |
| WEB-CHAT | live | waits on WEB-STATS; same BFF `/chat` |
| WEB-SITE | live | waits on WEB-STATS |
| WEB-LEGACY | dead | not this set |

Destination revision: `origin/main@d34459ca6ce6b5a01be7f6eae3faf2bc7251cfb6` (`docs/vision.md` / `docs/capabilities.md`).

## Observation (before)
- `GET https://kylet.se/` 200 HTML `data-freshness=stale` `data-observed-at=2026-08-09T20:40:47Z` (Last-Modified 2026-08-24T00:08:12Z, dest SHA on web-00013).
- `GET https://kylet.se/{healthz,stats,activity,projects,downloads,chat}` and `POST /chat` → Cloudflare `502` `error code: 502`.
- In-cluster web-00013: nginx `proxy_pass` to `API_INTERNAL_URL=http://api.portfolio-website.sylphx.internal:3001` → connection refused. `http://api.portfolio-website.svc.cluster.local:80/healthz` → `ok`.
- Direct api host `https://slim-pal-0k3stq.sylphx.app/healthz` 200 `ok`; `/stats` 200 `freshness=live`. HTTPRoute `api` is only that host; `kylet.se` is web catch-all `/` (path_prefixes not projected).
- Dest SHA `d34459c` (#40) envsubst'd Platform `API_INTERNAL_URL`, which is now `:3001` (container PORT), so the intended `:80` repair did not hold.
- Open leftover: Ready renovate PRs #38 #39 #41 #42 #43 #44 (api-rust lockfile only). They do **not** own the 502. Not folded. Not a second lockfile writer.

## Change
- Hardcode `$bff_upstream` to `http://api.portfolio-website.svc.cluster.local` (Knative ksvc / queue-proxy `:80`).
- `proxy_pass $bff_upstream$request_uri` so variable `proxy_pass` keeps the original path.
- Do not envsubst Platform `API_INTERNAL_URL` (`:3001`) into nginx.
- CI: `scripts/check-bff-upstream.sh` fails if `:3001` becomes `$bff_upstream`.

## Oracle
- `GET https://kylet.se/stats` → JSON `freshness=live` + `verifiedAt` (or `updatedAt`).
- `GET https://kylet.se/{healthz,activity,projects,downloads}` not 502.
- `POST https://kylet.se/chat` not 502.
- In-cluster `curl web:3000/stats` is not nginx 502 to `:3001`.

## Layer / recovery
- Source: this PR. **Do not land by the authoring Worker.** Ready SHA is for an independent judge.
- Runtime: Platform deploy of this web image (`autoDeployMode=after_ci`). Hands is sole kube writer — no product `kubectl apply`.
- `#38`–`#44` remain leftover, not this set.

## Floors
```text
Outcome: kylet.se /stats /activity /projects /downloads /healthz and /chat reach api-rust on ksvc :80, not 502
Applicable clause: standards/proof.md Truth layers (Live) postcondition; standards/platform.md Hands sole kube writer
Trigger: WEB-STATS live False; dest BFF still uses Platform container port :3001
Product mapping: nginx.conf $bff_upstream → api.portfolio-website.svc.cluster.local
Oracle: GET https://kylet.se/stats freshness=live + verifiedAt; in-cluster web /stats not connection-refused :3001
Gap or exception: none in this set; leftover renovate lockfile PRs #38 #39 #41 #42 #43 #44; edge path_prefixes still not on kylet.se HTTPRoute
```