### PR TITLE
fix(api): emit Responses input type=message on POST /chat

### DIFF
--- a/api-rust/src/chat.rs
+++ b/api-rust/src/chat.rs
@@ -233,6 +233,21 @@ fn message_text(m: &UIMessage) -> String {
     }
 }
 
+/// Official Responses EasyInputMessage. Gateway 400s `$.input[n].type`
+/// with "non-empty string is required" when `type` is omitted.
+fn responses_message_item(role: &str, text: String) -> Value {
+    let content_type = if role == "assistant" {
+        "output_text"
+    } else {
+        "input_text"
+    };
+    json!({
+        "type": "message",
+        "role": role,
+        "content": [{ "type": content_type, "text": text }],
+    })
+}
+
 /// Map UI messages to Responses `input` items (user/assistant text only;
 /// tool state is server-local across the loop).
 fn ui_messages_to_input_items(messages: &[UIMessage]) -> Vec<Value> {
@@ -244,14 +259,7 @@ fn ui_messages_to_input_items(messages: &[UIMessage]) -> Vec<Value> {
                 return None;
             }
             match m.role.as_str() {
-                "user" => Some(json!({
-                    "role": "user",
-                    "content": [{ "type": "input_text", "text": text }],
-                })),
-                "assistant" => Some(json!({
-                    "role": "assistant",
-                    "content": [{ "type": "output_text", "text": text }],
-                })),
+                "user" | "assistant" => Some(responses_message_item(&m.role, text)),
                 _ => None,
             }
         })
@@ -469,10 +477,7 @@ pub async fn handle_chat(body: ChatRequest, headers: &HeaderMap, cors: HeaderMap
                         StepOutcome::ToolCalls { text, calls } => {
                             // Append assistant items + tool outputs, then loop.
                             if !text.is_empty() {
-                                conversation_input.push(json!({
-                                    "role": "assistant",
-                                    "content": [{ "type": "output_text", "text": text }],
-                                }));
+                                conversation_input.push(responses_message_item("assistant", text));
                             }
                             for call in &calls {
                                 emit_event(&tx, json!({ "type": "tool-input-start", "toolCallId": call.id, "toolName": call.name }));
@@ -842,10 +847,42 @@ mod tests {
         ];
         let items = ui_messages_to_input_items(&messages);
         assert_eq!(items.len(), 2);
+        assert_eq!(items[0]["type"], "message");
         assert_eq!(items[0]["role"], "user");
         assert_eq!(items[0]["content"][0]["type"], "input_text");
+        assert_eq!(items[1]["type"], "message");
         assert_eq!(items[1]["role"], "assistant");
         assert_eq!(items[1]["content"][0]["type"], "output_text");
+        for (i, item) in items.iter().enumerate() {
+            let ty = item.get("type").and_then(Value::as_str).unwrap_or("");
+            assert!(
+                !ty.is_empty(),
+                "Responses input[{i}] omitted type (gateway 400): {item}"
+            );
+        }
+    }
+
+    #[test]
+    fn responses_input_items_pin_fails_without_type_message() {
+        let missing_type = json!({
+            "role": "user",
+            "content": [{ "type": "input_text", "text": "hello" }],
+        });
+        assert!(
+            missing_type
+                .get("type")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .is_empty(),
+            "fixture must omit type so the pin can fail closed"
+        );
+        let typed = responses_message_item("user", "hello".into());
+        assert_eq!(typed["type"], "message");
+        assert_ne!(
+            typed.get("type"),
+            missing_type.get("type"),
+            "typed message item must not match the untyped payload that 400s the gateway"
+        );
     }
 
     #[test]

--- a/api-rust/tests/wiremock_chat.rs
+++ b/api-rust/tests/wiremock_chat.rs
@@ -8,6 +8,38 @@ use tower::ServiceExt;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
+fn assert_gateway_input_items_have_type_message(body: &[u8]) {
+    let payload: serde_json::Value = serde_json::from_slice(body).expect("gateway JSON");
+    let input = payload
+        .get("input")
+        .and_then(|v| v.as_array())
+        .expect("input array");
+    assert!(!input.is_empty(), "gateway input must not be empty: {payload}");
+    for (i, item) in input.iter().enumerate() {
+        let ty = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        assert!(
+            !ty.is_empty(),
+            "$.input[{i}].type omitted (gateway 400 non-empty string is required): {item}"
+        );
+        let role = item.get("role").and_then(|v| v.as_str()).unwrap_or("");
+        if role == "user" || role == "assistant" {
+            assert_eq!(
+                ty, "message",
+                "$.input[{i}] role={role} must be type=message: {item}"
+            );
+        }
+    }
+    let tools = payload
+        .get("tools")
+        .and_then(|v| v.as_array())
+        .expect("tools array");
+    assert_eq!(
+        tools.len(),
+        5,
+        "POST /chat must keep five tools: {tools:?}"
+    );
+}
+
 #[tokio::test]
 #[serial]
 async fn chat_endpoint_streams_gateway_responses_sse_from_wiremock() {
@@ -57,6 +89,90 @@ data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r1\",\"status\":\"
     assert!(text.contains("text-delta"), "stream missing deltas: {text}");
     assert!(text.contains("Hello"));
     assert!(text.contains("[DONE]"));
+
+    let received = server.received_requests().await.expect("received");
+    assert_eq!(received.len(), 1, "expected one gateway call, got {}", received.len());
+    assert_gateway_input_items_have_type_message(&received[0].body);
+}
+
+#[tokio::test]
+#[serial]
+async fn chat_posts_responses_input_items_with_type_message() {
+    let server = MockServer::start().await;
+    testing::reset_all();
+    unsafe {
+        std::env::set_var("SYLPHX_AI_URL", server.uri());
+        std::env::set_var("SYLPHX_AI_API_KEY", "sk-wiremock");
+        std::env::remove_var("SYLPHX_URL");
+        std::env::remove_var("AI_GATEWAY_BASE_URL");
+        std::env::remove_var("AI_GATEWAY_KEY");
+    }
+
+    let sse = "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r1\",\"status\":\"completed\",\"output\":[{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"ok\"}]}]}}\n\n";
+
+    Mock::given(method("POST"))
+        .and(path("/v1/responses"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_raw(sse, "text/event-stream"),
+        )
+        .mount(&server)
+        .await;
+
+    let body = json!({
+        "messages": [
+            {"role": "user", "parts": [{"type": "text", "text": "hello kyle"}]},
+            {"role": "assistant", "parts": [{"type": "text", "text": "hi"}]},
+            {"role": "user", "parts": [{"type": "text", "text": "list a repo"}]}
+        ]
+    });
+
+    let app = router();
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/chat")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(res.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let text = String::from_utf8_lossy(&bytes);
+    assert!(text.contains("[DONE]"), "{text}");
+
+    let received = server.received_requests().await.expect("received");
+    assert_eq!(received.len(), 1);
+    let payload: serde_json::Value =
+        serde_json::from_slice(&received[0].body).expect("gateway JSON");
+    assert_gateway_input_items_have_type_message(&received[0].body);
+    assert_eq!(payload["input"][0]["type"], "message");
+    assert_eq!(payload["input"][0]["role"], "user");
+    assert_eq!(payload["input"][1]["type"], "message");
+    assert_eq!(payload["input"][1]["role"], "assistant");
+    assert_eq!(payload["input"][2]["type"], "message");
+    assert_eq!(payload["input"][2]["role"], "user");
+    let names: Vec<&str> = payload["tools"]
+        .as_array()
+        .expect("tools")
+        .iter()
+        .filter_map(|t| t.get("name").and_then(|n| n.as_str()))
+        .collect();
+    assert_eq!(
+        names,
+        [
+            "list_projects",
+            "get_repo",
+            "recent_activity",
+            "search_projects",
+            "npm_downloads"
+        ]
+    );
 }
 
 #[tokio::test]

--- a/api-rust/tests/wiremock_chat_tools.rs
+++ b/api-rust/tests/wiremock_chat_tools.rs
@@ -94,4 +94,38 @@ data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r2\",\"status\":\"
     assert!(text.contains("tool-output-available"), "{text}");
     assert!(text.contains("tool-repo"), "{text}");
     assert!(text.contains("Grounded."), "{text}");
+
+    let received = gw.received_requests().await.expect("received");
+    assert_eq!(received.len(), 2, "tool loop should call gateway twice");
+    for (n, req) in received.iter().enumerate() {
+        let payload: serde_json::Value =
+            serde_json::from_slice(&req.body).expect("gateway JSON");
+        let input = payload["input"].as_array().expect("input");
+        for (i, item) in input.iter().enumerate() {
+            let ty = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
+            assert!(
+                !ty.is_empty(),
+                "step {n} $.input[{i}].type omitted: {item}"
+            );
+            let role = item.get("role").and_then(|v| v.as_str()).unwrap_or("");
+            if role == "user" || role == "assistant" {
+                assert_eq!(
+                    ty, "message",
+                    "step {n} $.input[{i}] must be type=message: {item}"
+                );
+            }
+        }
+        assert_eq!(payload["tools"].as_array().map(Vec::len), Some(5));
+    }
+    let second: serde_json::Value =
+        serde_json::from_slice(&received[1].body).expect("second gateway JSON");
+    let types: Vec<&str> = second["input"]
+        .as_array()
+        .expect("input")
+        .iter()
+        .filter_map(|item| item.get("type").and_then(|v| v.as_str()))
+        .collect();
+    assert!(types.contains(&"message"), "{types:?}");
+    assert!(types.contains(&"function_call"), "{types:?}");
+    assert!(types.contains(&"function_call_output"), "{types:?}");
 }


### PR DESCRIPTION
## Write/effect
`POST /chat` must emit official Responses input items with `"type":"message"` (keep five tools).

## Identities
| ID | Fate | Layer |
| --- | --- | --- |
| WEB-CHAT | live | source |
| WEB-STATS | live | dest already landed; not this set |
| WEB-SITE | live | not this set |
| WEB-LEGACY | dead | not this set |

Destination revision: `origin/main@7cf46f7fceb92d300f00b3c4028f9a43b3afd853` (`docs/vision.md` / `docs/capabilities.md`).

## Observation (before)
- `ui_messages_to_input_items` sent `{role, content:[{type:input_text,text}]}` without `type=message`.
- Gateway 400: `non-empty string is required` on `$.input[n].type`.
- Tool-loop assistant follow-ups had the same untyped shape.

## Change
- Emit EasyInputMessage `{type:message, role, content}` for user/assistant text.
- Same helper for tool-loop assistant items; `function_call` / `function_call_output` already typed.
- Keep five tools: `list_projects`, `get_repo`, `recent_activity`, `search_projects`, `npm_downloads`.

## Oracle
- `ui_messages_map_to_responses_input_items` fails if items omit `type=message`.
- `chat_posts_responses_input_items_with_type_message` inspects the real `POST /v1/responses` body from `POST /chat`.
- Tool-loop pin: both gateway steps have typed input; five tools remain.
- Live later is not this SHA alone.

## Layer / recovery
- Source: this PR. **Do not land by the authoring Worker.** Ready SHA is for an independent judge.
- Runtime: Platform deploy of api (`autoDeployMode=after_ci`). Hands is sole kube writer.
- Out of set: renovate lockfiles; WEB-STATS nginx; AI catalog #2304; identity pin.

## Floors
```text
Outcome: POST /chat gateway input items have type=message; five tools kept
Applicable clause: standards/PRINCIPLES.md Correctness; standards/exceptions.md Owning writer
Trigger: fact crosses api-rust → Sylphx AI Gateway; untyped input 400s live chat
Product mapping: api-rust/src/chat.rs responses_message_item / ui_messages_to_input_items
Oracle: pin fails if $.input[n].type is omitted or not message for role items
Gap or exception: none in this set; live WEB-CHAT remaining false is later, not this SHA
```