### PR TITLE
fix(api): fail-close /chat/ready unless dest sk-sx- key

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,14 @@ Kyle Tse's personal proof surface: a static portfolio with a small Rust live API
 | Var | Purpose |
 | --- | --- |
 | `SYLPHX_AI_URL` | Gateway base (default `https://api.sylphx.ai`, normalized to `/v1`) |
-| `SYLPHX_AI_API_KEY` | Gateway bearer credential (`ck_*` / `sk-sx-*`) |
+| `SYLPHX_AI_API_KEY` | Gateway bearer credential (`sk-sx-*` only; dest AI peel) |
 | `AI_GATEWAY_BASE_URL` / `AI_GATEWAY_KEY` / `AI_GATEWAY_API_KEY` | Explicit overrides (optional) |
 | `AI_MODEL` | Responses model (default `sylphx/auto`) |
 
 **Must not** set `AI_GATEWAY_BASE_URL` to Platform management (`api.sylphx.com`)
-or `AI_GATEWAY_KEY` to a Platform product secret (`sk_prod_*`) — those produce
-`unsupported_credential` and are rejected by `resolve_ai()` (ADR-169 honesty).
+or `AI_GATEWAY_KEY` to a Platform product secret (`sk_prod_*`), leftover
+internal `ck_*`, or any non-`sk-sx-*` bearer — those are rejected by
+`resolve_ai()` so `GET /chat/ready` stays fail-closed (ADR-169 honesty).
 
 `SYLPHX_URL` is **never** used as a server credential. Without a valid gateway
 credential the API fails closed (`503 chat is warming up`). UI probes

--- a/api-rust/src/chat.rs
+++ b/api-rust/src/chat.rs
@@ -92,24 +92,13 @@ fn is_forbidden_gateway_host(host: &str) -> bool {
         || h == "app.sylphx.com"
 }
 
-/// Reject credentials that belong to Platform product/management planes.
-/// Live incident (2026-08-10): `AI_GATEWAY_KEY=sk_prod_…` is a Platform
-/// project secret, not a Sylphx AI data-plane key (`ck_*` / `sk-sx-*`).
+/// Dest AI peel admits `sk-sx-…` only (`AI-SERVICE-KEY-AUTH`).
+/// Platform `sk_prod_*` / JWT / `sylphx://` and leftover internal `ck_*`
+/// mint public `401 invalid_api_key` at `api.sylphx.ai`. A non-empty check
+/// used to report `GET /chat/ready` ready=true for `ck_*` (live 2026-09-04).
 fn is_plausible_gateway_key(key: &str) -> bool {
     let k = key.trim();
-    if k.is_empty() || k.len() < 8 {
-        return false;
-    }
-    if k.starts_with("sk_prod_")
-        || k.starts_with("sk_prev_")
-        || k.starts_with("pk_prod_")
-        || k.starts_with("pk_prev_")
-        || k.starts_with("sylphx://")
-        || k.starts_with("eyJ")
-    {
-        return false;
-    }
-    true
+    k.len() >= 8 && k.starts_with("sk-sx-")
 }
 
 fn first_env(names: &[&str]) -> Option<String> {
@@ -930,13 +919,15 @@ mod tests {
     }
 
     #[test]
-    fn rejects_platform_product_keys() {
+    fn rejects_non_dest_gateway_keys() {
         assert!(!is_plausible_gateway_key("sk_prod_0288deadbeef"));
         assert!(!is_plausible_gateway_key("pk_prod_abc"));
         assert!(!is_plausible_gateway_key("sylphx://pk_prod_x@unit.api.sylphx.com"));
         assert!(!is_plausible_gateway_key("eyJhbGciOiJIUzI1NiJ9.e30.sig"));
-        assert!(is_plausible_gateway_key("ck_8cdf15c1c_testkey"));
+        assert!(!is_plausible_gateway_key("ck_8cdf15c1c_testkey"));
+        assert!(!is_plausible_gateway_key("sk-wiremock"));
+        assert!(!is_plausible_gateway_key("sk-sx-"));
         assert!(is_plausible_gateway_key("sk-sx-abcdefghijklmnop"));
-        assert!(is_plausible_gateway_key("sk-wiremock"));
+        assert!(is_plausible_gateway_key("sk-sx-wiremock"));
     }
 }

--- a/api-rust/tests/wiremock_chat.rs
+++ b/api-rust/tests/wiremock_chat.rs
@@ -47,7 +47,7 @@ async fn chat_endpoint_streams_gateway_responses_sse_from_wiremock() {
     testing::reset_all();
     unsafe {
         std::env::set_var("SYLPHX_AI_URL", server.uri());
-        std::env::set_var("SYLPHX_AI_API_KEY", "sk-wiremock");
+        std::env::set_var("SYLPHX_AI_API_KEY", "sk-sx-wiremock");
         std::env::remove_var("SYLPHX_URL");
         std::env::remove_var("AI_GATEWAY_BASE_URL");
         std::env::remove_var("AI_GATEWAY_KEY");
@@ -102,7 +102,7 @@ async fn chat_posts_responses_input_items_with_type_message() {
     testing::reset_all();
     unsafe {
         std::env::set_var("SYLPHX_AI_URL", server.uri());
-        std::env::set_var("SYLPHX_AI_API_KEY", "sk-wiremock");
+        std::env::set_var("SYLPHX_AI_API_KEY", "sk-sx-wiremock");
         std::env::remove_var("SYLPHX_URL");
         std::env::remove_var("AI_GATEWAY_BASE_URL");
         std::env::remove_var("AI_GATEWAY_KEY");
@@ -200,6 +200,102 @@ async fn chat_fails_closed_without_gateway_credentials() {
         .await
         .unwrap();
     assert_eq!(res.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+#[serial]
+async fn chat_ready_fails_closed_for_leftover_internal_ck_key() {
+    // Live 2026-09-04: dest host + leftover ck_* reported ready=true while
+    // POST /chat streamed gateway 401 invalid_api_key.
+    testing::reset_all();
+    unsafe {
+        std::env::set_var("AI_GATEWAY_BASE_URL", "https://api.sylphx.ai");
+        std::env::set_var("SYLPHX_AI_URL", "https://api.sylphx.ai");
+        std::env::set_var("AI_GATEWAY_KEY", "ck_8cdf15c1c_testkey");
+        std::env::set_var("SYLPHX_AI_API_KEY", "ck_8cdf15c1c_testkey");
+        std::env::remove_var("SYLPHX_URL");
+        std::env::remove_var("AI_GATEWAY_API_KEY");
+    }
+    let app = router();
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/chat/ready")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(res.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&bytes).expect("ready json");
+    assert_eq!(body["ready"], false, "{body}");
+    assert_eq!(body["reason"], "missing_or_invalid_gateway_key", "{body}");
+    assert_eq!(body["host"], "api.sylphx.ai", "{body}");
+}
+
+#[tokio::test]
+#[serial]
+async fn chat_post_fails_closed_for_leftover_internal_ck_key() {
+    testing::reset_all();
+    unsafe {
+        std::env::set_var("AI_GATEWAY_BASE_URL", "https://api.sylphx.ai");
+        std::env::set_var("AI_GATEWAY_KEY", "ck_8cdf15c1c_testkey");
+        std::env::set_var("SYLPHX_AI_API_KEY", "ck_8cdf15c1c_testkey");
+        std::env::remove_var("SYLPHX_URL");
+        std::env::remove_var("AI_GATEWAY_API_KEY");
+    }
+    let body = json!({
+        "messages": [{"role": "user", "parts": [{"type": "text", "text": "hi"}]}]
+    });
+    let app = router();
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/chat")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+#[serial]
+async fn chat_ready_true_for_dest_sk_sx_key() {
+    testing::reset_all();
+    unsafe {
+        std::env::set_var("AI_GATEWAY_BASE_URL", "https://api.sylphx.ai");
+        std::env::set_var("SYLPHX_AI_API_KEY", "sk-sx-wiremock");
+        std::env::remove_var("AI_GATEWAY_KEY");
+        std::env::remove_var("AI_GATEWAY_API_KEY");
+        std::env::remove_var("SYLPHX_URL");
+    }
+    let app = router();
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/chat/ready")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(res.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&bytes).expect("ready json");
+    assert_eq!(body["ready"], true, "{body}");
+    assert_eq!(body["reason"], serde_json::Value::Null, "{body}");
+    assert_eq!(body["host"], "api.sylphx.ai", "{body}");
 }
 
 #[tokio::test]

--- a/api-rust/tests/wiremock_chat_tools.rs
+++ b/api-rust/tests/wiremock_chat_tools.rs
@@ -18,7 +18,7 @@ async fn chat_tool_loop_list_projects_grounded_by_wiremock_github() {
         std::env::set_var("GITHUB_API_BASE", gh.uri());
         std::env::set_var("GITHUB_TOKEN", "wiremock-token");
         std::env::set_var("SYLPHX_AI_URL", gw.uri());
-        std::env::set_var("SYLPHX_AI_API_KEY", "sk-wiremock");
+        std::env::set_var("SYLPHX_AI_API_KEY", "sk-sx-wiremock");
         std::env::remove_var("SYLPHX_URL");
         std::env::remove_var("AI_GATEWAY_BASE_URL");
         std::env::remove_var("AI_GATEWAY_KEY");
@@ -134,7 +134,7 @@ async fn chat_get_repo_returns_null_for_non_public_repository() {
         std::env::set_var("GITHUB_API_BASE", gh.uri());
         std::env::set_var("GITHUB_TOKEN", "wiremock-token");
         std::env::set_var("SYLPHX_AI_URL", gw.uri());
-        std::env::set_var("SYLPHX_AI_API_KEY", "sk-wiremock");
+        std::env::set_var("SYLPHX_AI_API_KEY", "sk-sx-wiremock");
         std::env::remove_var("SYLPHX_URL");
         std::env::remove_var("AI_GATEWAY_BASE_URL");
         std::env::remove_var("AI_GATEWAY_KEY");


### PR DESCRIPTION
## Identity

- **ID:** WEB-CHAT
- **Fate:** live
- **Writer:** `shtse8/portfolio-website` (this source SHA). Platform secret for `kylet.se` is a separate layer and is **not** written here.
- **Dest revision (origin/main):**
  - `docs/vision.md` `a55bbbaf55e3f64d601d1241898f761c0495dd67`
  - `docs/capabilities.md` `a51220dc96f3d9de20658adc314df028ffb16549`
- **Candidate SHA:** `e9c4a9b37bb6a440b7075ebe97c437b582cbf9e0`
- **Layer:** source (public `/chat` + `/chat/ready` contract)
- **Harm:** HIGH (public contracts). Do not land without independent `judge-sha`. This SHA was not self-landed.

## Write / effect

Fail-close the public chat contract unless the server credential is dest AI peel `sk-sx-…`.

Live 2026-09-04: `GET https://kylet.se/chat/ready` returned `ready:true` (host `api.sylphx.ai`, model `sylphx/auto`) while stranger `POST /chat` streamed `gateway 401 Unauthorized` / `invalid_api_key`. Runtime env is leftover internal `ck_*` (len 35) on dest host. Dest AI peel (`AI-SERVICE-KEY-AUTH`) admits `sk-sx-` only; non-`sk-sx-` including internal `ck_*` is public 401.

`is_plausible_gateway_key` previously accepted any non-Platform-shaped non-empty key, including `ck_*`. This change requires `sk-sx-` (length ≥ 8). `resolve_ai()` then leaves the key empty, so:

- `GET /chat/ready` → `ready:false`, `reason=missing_or_invalid_gateway_key`
- `POST /chat` → `503` warming-up (does not proxy a gateway 401)

UI already fail-closes the launcher on `ready=false`.

## Oracle

Source (this SHA, `cargo test --locked -- --test-threads=1` in `api-rust`):

- `chat_ready_fails_closed_for_leftover_internal_ck_key` — `GET /chat/ready` with dest host + `ck_*` → `ready=false`
- `chat_post_fails_closed_for_leftover_internal_ck_key` — `POST /chat` with `ck_*` → 503
- `chat_ready_true_for_dest_sk_sx_key` — dest `sk-sx-` still `ready=true`
- existing wiremock stream tests keep working with fixture `sk-sx-wiremock`

Live after land+deploy (not this PR): `GET https://kylet.se/chat/ready` is `ready:false` while the leftover `ck_*` remains. Stranger `POST /chat` must not stream `invalid_api_key`.

Dest `Done when` (POST succeeds under dest auth) still needs a **project-owned** `sk-sx-` installed as Platform secret (`SYLPHX_AI_API_KEY` / `AI_GATEWAY_KEY`) for `proj` `curl-nod-67h1zf` / live ns `portfolio-website`. This SHA does not mint or set that secret.

## Recovery

- If this contract is wrong: revert this SHA; `/chat/ready` returns to lying `ready=true` on leftover `ck_*`.
- To make dest POST succeed: Platform management credential that can `POST /v1/ai/projects/{projectId}/gateway` (or customer `POST https://api.sylphx.ai/v1/keys`) then `sylphx secrets set` / `sylphx env set` for this project; wait for secret projection + api recycle. Do not kubectl-patch `app-env-api` (Hands is kube writer; Platform is secret writer). Do not reuse another product's `sk-sx-`.

## Floors

```
Outcome: WEB-CHAT public /chat/ready is false unless dest sk-sx- key; POST /chat does not stream gateway 401 for leftover ck_*
Applicable clause: standards/work.md High-harm surfaces (public contracts); PRINCIPLES.md Correctness; exceptions.md Owning writer; proof.md Postcondition, not proxy
Trigger: public /chat and /chat/ready; credential shape is dest peel; tests name the public postcondition
Product mapping: api-rust/src/chat.rs is_plausible_gateway_key / chat_readiness / handle_chat
Oracle: GET /chat/ready with ck_* → ready=false; POST /chat with ck_* → 503; sk-sx- still ready and wiremock streams
Gap: live dest POST success still owned by Platform secret write; this SHA does not write that secret
```

## Out of set

- WEB-STATS source/files not touched
- Renovate PRs #56 / #57 not touched
- No Platform secret write (management auth unusable: stored CLI OAuth expired 2026-09-03; `slx_cli_*` → `legacy_pat_removed`; identity token endpoint for stored issuer 404)
- Cubloom GOV-008 out
