### PR TITLE
build(api): copy whole crate so BuildKit cannot reuse stale cargo layer

### DIFF
--- a/api-rust/Dockerfile
+++ b/api-rust/Dockerfile
@@ -1,9 +1,12 @@
 # kylet-api-rust — Rust sole authority for kylet.se live API (ADR-169).
 # Build context is the repository root (api-rust/ only).
 FROM rust:1-bookworm AS builder
+WORKDIR /workspace
+# Production BuildKit mode=min registry cache served a stale
+# `COPY api-rust/src` hit after #52/#58, leaving live on 9016192.
+# Copy the whole crate in one instruction so cargo cannot reuse that layer.
+COPY api-rust /workspace/api-rust
 WORKDIR /workspace/api-rust
-COPY api-rust/Cargo.toml api-rust/Cargo.lock ./
-COPY api-rust/src ./src
 ENV CARGO_BUILD_JOBS=2
 RUN cargo build --locked --release
 


### PR DESCRIPTION
## Identity

- **IDs:** WEB-STATS, WEB-CHAT
- **Fate:** live (unchanged; this SHA does not change graph fate)
- **Writer:** `shtse8/portfolio-website` `api-rust/Dockerfile` only. Hands/Apps own ksvc apply; Platform owns secrets. This SHA does not kubectl-patch and does not write `app-env-api`.
- **Dest revision (origin/main, unchanged):**
  - `docs/vision.md` `a55bbbaf55e3f64d601d1241898f761c0495dd67`
  - `docs/capabilities.md` `a51220dc96f3d9de20658adc314df028ffb16549`
- **Candidate SHA:** `acdaeaf747248e9c6ad5aa9887d04ed179145e3a`
- **Layer:** source / build packaging (BuildKit cache key). Not public JSON contract text, not identity speech, not dest-lock.
- **Harm:** ordinary (packaging). Public `/stats` `/activity` `/claims` `/chat` bytes do not change in this SHA; they change only after Hands rolls an actually-compiled #52+#58 binary that already landed on `origin/main`.

## Write / effect

Bust the poisoned production API BuildKit cache so the next production build of this tree **compiles** `api-rust` instead of reusing a stale cargo layer.

Live 2026-09-04T23:28Z `https://kylet.se` is still the pre-#52 binary:

- ksvc `api` revision `api-00015`, image digest `sha256:6c212edfaf5c0c08e16ab0fb3228d8298310b1a3b10b1806a8d700a63790e9b9`, `SYLPHX_GIT_COMMIT_SHA=901619208e0a14b321db95d2b410125c720621a8` (#51)
- `GET /chat/ready` `ready:true` (host `api.sylphx.ai`, model `sylphx/auto`)
- `GET /stats` has `freshness=live` + `verifiedAt` and **no** `repositoryVisibility`
- `GET /activity` **no** `projectionRevision`
- `GET /claims` `activityDefinition.includes` still contains “including private repos the token can see”

Source on `origin/main` `3646fb2` already has #52 public-only projections and #58 `sk-sx-` fail-close. Platform **did** build `3646fb2` for production env `0e347acf-0469-4ab2-9531-eeef8927b46b`:

- job `mgmt-build-019f0fdb7ecb7f75b4897c4f026ff0cf-3646fb2ba089` 23:07:39–23:07:49 (~10s)
- checkout: `HEAD is now at 3646fb2 … (#58)`
- `COPY api-rust/src ./src` **CACHED**, `RUN cargo build --locked --release` **CACHED**, no `Compiling kylet*`
- tagged `…-api:3646fb2ba089@sha256:1de4ea600a9fdb4bd61488d5a0bf63685c2b0c6ca039b7b772e49e596b20c49b` ≠ live `6c212edf…` but layers are the stale cache
- cache: `mode=min` `direct_buildkit_git_buildctl` ref `…/env-0e347acf-…/svc-api/dockerfile-api-rust-dockerfile:buildcache`

Replace the two COPY instructions (`Cargo.toml`/`Cargo.lock`, then `src`) with one `COPY api-rust /workspace/api-rust` so the cargo RUN cannot reuse that layer. Runtime stage and binary path `/workspace/api-rust/target/release/kylet-api-rust` are unchanged.

## Oracle

This SHA (build layer): the next production `mgmt-build-019f0fdb-7ecb-7f75-b489-7c4f026ff0cf` log for this git SHA shows **non-CACHED** `RUN cargo build --locked --release` and `Compiling kylet-api-rust` (or `Compiling kylet*`). A 10s CACHED cargo is a miss.

Live after Hands rolls the compiled digest onto ksvc `api` (not this SHA; Hands is kube writer):

- `GET https://kylet.se/stats` `repositoryVisibility==public-only/v1`
- `GET https://kylet.se/activity` `projectionRevision==github-public-only/v1`
- `GET https://kylet.se/claims` includes text has **no** “private repos”
- `GET https://kylet.se/chat/ready` `ready==false` while leftover `ck_*` remains
- `POST /chat` must **not** stream `invalid_api_key` (expect 503 warming-up)
- ksvc `api` `SYLPHX_GIT_COMMIT_SHA` ≠ `9016192`

Dest WEB-CHAT `Done when` (successful POST with tools) still needs a project-owned `sk-sx-` for `proj` `curl-nod-67h1zf` / env `0e347acf-…`. Separate Platform secret write; not this PR.

## Recovery

- If this packaging is wrong: revert this SHA. The two-COPY Dockerfile returns; production may again hit the stale `COPY src` cache.
- If cargo compiles but ksvc stays `api-00015`: blocked triple — owning writer **Apps/Hands** (project `curl-nod-67h1zf` / env `0e347acf-0469-4ab2-9531-eeef8927b46b` / ns `portfolio-website`). Unblock = apply the **compiled** image digest onto ksvc `api`. Do not kubectl-patch from this worker.
- Do not restore a pre-#52 binary as recovery for live honesty.

## Ordinary review (self-checklist)

Harm is packaging, not public-contract listing or identity speech in this SHA. Disconfirmation:

- [x] Write-set is only `api-rust/Dockerfile`. Root `Dockerfile` (#57), chat/stats/claims source, dest blobs, renovate PRs, and kube/secrets are untouched.
- [x] Runtime `COPY --from=builder` path still `/workspace/api-rust/target/release/kylet-api-rust`.
- [x] Instruction string and copy source both change (`COPY api-rust` vs `COPY api-rust/src`), so a content-blind or src-checksum-poisoned `mode=min` cache cannot reuse builder step 4/5.
- [x] Crate copy does not add a second data plane, `/version` SHA, or root `.dockerignore`.
- [x] Live oracles named above are customer GETs after Hands roll, not a Dockerfile grep.
- [x] Failures that would reject land: cargo RUN still CACHED on the next production build of this SHA; binary path missing at runtime; this PR edits occupied root `Dockerfile` or public JSON.

## Out of set

- Chat/stats/claims source (already correct on `3646fb2`)
- Dest-lock / NORTH_STAR
- Renovate #56–#64 (root `Dockerfile` = #57)
- Platform `sk-sx-` secret install
- kubectl-patch of ksvc or `app-env-api`
- GH Actions runner class (CI queued; Platform builds independently)
