### PR TITLE
build(api): stage binary at /out so runtime COPY cannot reuse stale image

### DIFF
--- a/api-rust/Dockerfile
+++ b/api-rust/Dockerfile
@@ -8,12 +8,18 @@ WORKDIR /workspace
 COPY api-rust /workspace/api-rust
 WORKDIR /workspace/api-rust
 ENV CARGO_BUILD_JOBS=2
-RUN cargo build --locked --release
+# Stage the binary at /out: #65 compiled kylet-api-rust (~97s) then
+# runtime `COPY --from=builder .../target/release/kylet-api-rust` was
+# CACHED and the pushed digest stayed sha256:1de4ea600a9f… (same as the
+# stale 3646fb2 tag). A path that never existed in that cache cannot hit.
+RUN cargo build --locked --release \
+    && mkdir -p /out \
+    && cp target/release/kylet-api-rust /out/kylet-api-rust
 
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
-COPY --from=builder /workspace/api-rust/target/release/kylet-api-rust /usr/local/bin/kylet-api-rust
+COPY --from=builder /out/kylet-api-rust /usr/local/bin/kylet-api-rust
 ENV PORT=3001
 EXPOSE 3001
 USER 65532:65532


### PR DESCRIPTION
## Identity

- **IDs:** WEB-STATS, WEB-CHAT
- **Fate:** live (unchanged)
- **Writer:** `shtse8/portfolio-website` `api-rust/Dockerfile` only. Hands/Apps own ksvc apply. No kubectl-patch, no secret write.
- **Dest revision (origin/main, unchanged):**
  - `docs/vision.md` `a55bbbaf55e3f64d601d1241898f761c0495dd67`
  - `docs/capabilities.md` `a51220dc96f3d9de20658adc314df028ffb16549`
- **Candidate SHA:** `0e6e5b18a93834a6266bac7b5028c929abd1d94d`
- **Layer:** source / build packaging (BuildKit cache key). Repair of #65. Not public JSON, not identity speech, not dest-lock.
- **Harm:** ordinary (packaging).

## Write / effect

#65 (`663421e`) **did** bust the builder cargo cache: production job `mgmt-build-019f0fdb7ecb7f75b4897c4f026ff0cf-663421e20084` (env `0e347acf-0469-4ab2-9531-eeef8927b46b`) 23:35:56–23:37:59 compiled `kylet-api-rust v0.1.7` (`RUN cargo` 97.1s, not CACHED).

The runtime stage then served a stale image:

- `#16 COPY --from=builder /workspace/api-rust/target/release/kylet-api-rust` **CACHED**
- exported/pushed digest `sha256:1de4ea600a9fdb4bd61488d5a0bf63685c2b0c6ca039b7b772e49e596b20c49b` — **identical** to the poisoned `3646fb2` tag
- live ksvc still `api-00015` / `SYLPHX_GIT_COMMIT_SHA=9016192` / digest `6c212edf…` (Hands has not rolled)

Stage the compiled binary at `/out/kylet-api-rust` (path never present in that cache) and `COPY --from=builder /out/kylet-api-rust`. CMD still `kylet-api-rust`.

## Oracle

Next production `mgmt-build-019f0fdb-7ecb-7f75-b489-7c4f026ff0cf` log for this git SHA:

- `RUN cargo build` **not** CACHED and `Compiling kylet-api-rust`
- `COPY --from=builder /out/kylet-api-rust` **not** CACHED
- exporting manifest sha256 **≠** `1de4ea600a9fdb4bd61488d5a0bf63685c2b0c6ca039b7b772e49e596b20c49b` and **≠** live `6c212edfaf5c0c08e16ab0fb3228d8298310b1a3b10b1806a8d700a63790e9b9`

Live after Hands rolls that **new** digest onto ksvc `api`:

- `GET https://kylet.se/stats` `repositoryVisibility==public-only/v1`
- `GET https://kylet.se/activity` `projectionRevision==github-public-only/v1`
- `GET https://kylet.se/claims` includes text has **no** “private repos”
- `GET https://kylet.se/chat/ready` `ready==false` while leftover `ck_*` remains
- `POST /chat` must **not** stream `invalid_api_key` (expect 503 warming-up)
- ksvc `api` `SYLPHX_GIT_COMMIT_SHA` ≠ `9016192` and image digest ≠ `1de4ea60…` and ≠ `6c212edf…`

Dest WEB-CHAT POST-success still needs project-owned `sk-sx-` for `proj` `curl-nod-67h1zf`. Not this PR.

## Recovery

- Revert this SHA (and #65 if the two-COPY form must return). Do not roll `…-api:663421e20084@sha256:1de4ea60…` as recovery; that digest is the stale cache.
- If cargo+COPY compile a new digest but ksvc stays `api-00015`: blocked triple — **Apps/Hands** (project `curl-nod-67h1zf` / env `0e347acf-0469-4ab2-9531-eeef8927b46b` / ns `portfolio-website`). Unblock = apply the compiled digest, not `1de4ea60` / `6c212edf`.

## Ordinary review (self-checklist)

Repair of #65; new SHA; packaging only.

- [x] Write-set is only `api-rust/Dockerfile`. Root `Dockerfile` (#57), dest blobs, chat/stats source, kube/secrets untouched.
- [x] Runtime binary path remains `/usr/local/bin/kylet-api-rust`; CMD unchanged.
- [x] COPY source path `/out/kylet-api-rust` cannot match the cached `target/release/…` key that produced digest `1de4ea60`.
- [x] Oracle is the next build log + live GETs, not a Dockerfile grep.
- [x] Failures that reject land: cargo or `/out` COPY still CACHED; pushed digest still `1de4ea60` or `6c212edf`; this PR edits occupied root `Dockerfile` or public JSON.

## Out of set

- Dest-lock / NORTH_STAR
- Renovate #56–#64
- Platform `sk-sx-` secret
- kubectl-patch
- Rolling the `663421e` tag as-is
