### PR TITLE
build(api): install binary with RUN --mount, not destination-keyed COPY

### DIFF
--- a/api-rust/Dockerfile
+++ b/api-rust/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # kylet-api-rust — Rust sole authority for kylet.se live API (ADR-169).
 # Build context is the repository root (api-rust/ only).
 FROM rust:1-bookworm AS builder
@@ -19,7 +20,14 @@ RUN cargo build --locked --release \
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
-COPY --from=builder /out/kylet-api-rust /usr/local/bin/kylet-api-rust
+# Do not COPY --from the binary: #67 compiled then CACHED
+# `COPY --from=builder /out/kylet-api-rust` to /usr/local/bin/kylet-api-rust
+# and reused cache layers 146ce355/581dba8a/a8ac7f6c/f588acd2 (config-only
+# digest sha256:29d192fa…). Install via RUN --mount so this layer cannot
+# be that destination-keyed COPY.
+RUN --mount=from=builder,source=/out,target=/mnt \
+    cp /mnt/kylet-api-rust /usr/local/bin/kylet-api-rust \
+    && chmod 0755 /usr/local/bin/kylet-api-rust
 ENV PORT=3001
 EXPOSE 3001
 USER 65532:65532


### PR DESCRIPTION
## Identity

- **IDs:** WEB-STATS, WEB-CHAT
- **Fate:** live (unchanged)
- **Writer:** `shtse8/portfolio-website` `api-rust/Dockerfile` only. Hands/Apps own ksvc apply. No kubectl-patch, no secret write.
- **Dest revision (origin/main, unchanged):**
  - `docs/vision.md` `a55bbbaf55e3f64d601d1241898f761c0495dd67`
  - `docs/capabilities.md` `a51220dc96f3d9de20658adc314df028ffb16549`
- **Candidate SHA:** `dc153b3da4b4f8131236cbab125168ced33ddb02`
- **Layer:** source / build packaging (BuildKit cache key). Repair of #65 and #67. Not public JSON, not identity speech, not dest-lock.
- **Harm:** ordinary (packaging).

## Write / effect

#65/#67 compiled `kylet-api-rust` on production BuildKit (~97s) but the **runtime image still reused stale layers**.

#67 job `mgmt-build-019f0fdb7ecb7f75b4897c4f026ff0cf-d8b327f56d98` (env `0e347acf-0469-4ab2-9531-eeef8927b46b`) 23:41:28–23:43:31:

- `Compiling kylet-api-rust v0.1.7`
- `COPY --from=builder /out/kylet-api-rust /usr/local/bin/kylet-api-rust` **CACHED**
- cache export layers **identical** to the poisoned 3646fb2 set: `146ce355`, `581dba8a`, `a8ac7f6c`, `f588acd2`
- pushed digest `sha256:29d192fa483da0369f54413ecde25b563ce6cea1a5bd6b8c2b8120cb879a1a8b` — **config-only** change vs `1de4ea60…` (COPY source string), not a new binary layer
- live ksvc still `api-00015` / `9016192` / `6c212edf…`

Replace runtime `COPY --from` with `RUN --mount=from=builder,source=/out,target=/mnt` + `cp` so the install layer cannot hit the destination-keyed COPY cache. CMD still `kylet-api-rust`.

## Oracle

Next production `mgmt-build-019f0fdb-7ecb-7f75-b489-7c4f026ff0cf` log for this git SHA:

- `RUN cargo build` **not** CACHED and `Compiling kylet-api-rust`
- runtime `RUN --mount=from=builder` **not** CACHED
- no `COPY --from=builder` of the binary
- cache/image layer hashes **include at least one id not in** `{146ce355, 581dba8a, a8ac7f6c, f588acd2}`
- exporting manifest sha256 **≠** `29d192fa…`, **≠** `1de4ea60…`, **≠** `6c212edf…`

Live after Hands rolls that **new-layer** digest onto ksvc `api`:

- `GET https://kylet.se/stats` `repositoryVisibility==public-only/v1`
- `GET https://kylet.se/activity` `projectionRevision==github-public-only/v1`
- `GET https://kylet.se/claims` includes text has **no** “private repos”
- `GET https://kylet.se/chat/ready` `ready==false` while leftover `ck_*` remains
- `POST /chat` must **not** stream `invalid_api_key` (expect 503 warming-up)
- ksvc `api` `SYLPHX_GIT_COMMIT_SHA` ≠ `9016192` and image digest is the new-layer digest above

Dest WEB-CHAT POST-success still needs project-owned `sk-sx-` for `proj` `curl-nod-67h1zf`. Not this PR.

## Recovery

- Revert this SHA. Do **not** roll `…:d8b327f56d98@sha256:29d192fa…` or `…:663421e20084@sha256:1de4ea60…` as recovery; those tags are config/cache, not a new binary.
- If RUN --mount is CACHED and layer set is still `{146ce355,581dba8a,a8ac7f6c,f588acd2}`: this Dockerfile cannot defeat a fully instruction-blind runtime cache; owning writer is **Apps/BuildKit** for `mode=min` registry cache on `svc-api` env `0e347acf-…` (content-address the builder snapshot). Do not kubectl-patch.
- If a new-layer digest exists but ksvc stays `api-00015`: blocked triple **Apps/Hands** (project `curl-nod-67h1zf` / env `0e347acf-0469-4ab2-9531-eeef8927b46b` / ns `portfolio-website`). Unblock = apply that digest, not `29d192fa` / `1de4ea60` / `6c212edf`.

## Ordinary review (self-checklist)

Repair of #65/#67; new SHA; packaging only.

- [x] Write-set is only `api-rust/Dockerfile`. Root `Dockerfile` (#57), dest blobs, chat/stats source, kube/secrets untouched.
- [x] Runtime binary path remains `/usr/local/bin/kylet-api-rust`; CMD unchanged.
- [x] Install layer is `RUN --mount`, not `COPY --from` to `/usr/local/bin/kylet-api-rust`.
- [x] Oracle requires a **new layer hash**, not merely a new manifest digest (config-only miss of #67).
- [x] Failures that reject land: RUN --mount CACHED with the same four layer ids; digest-only change; public JSON / dest-lock / root Dockerfile.

## Out of set

- Dest-lock / NORTH_STAR
- Renovate #56–#64
- Platform `sk-sx-` secret
- kubectl-patch
- Rolling `d8b327f` / `663421e` tags as-is
