### PR TITLE
fix(site): label career-scale claims as self-attested pedigree

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Kyle Tse Portfolio",
   "short_name": "Kyle Tse",
-  "description": "Kyle Tse — AI infrastructure builder. MCP servers, AI-native developer tools, and the Sylphx AI platform. 20 years shipping at scale.",
+  "description": "Kyle Tse — AI infrastructure builder. MCP servers, AI-native developer tools, and the Sylphx AI platform. Live GitHub/npm proof on kylet.se; career history is self-attested historical pedigree.",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#0a0a0c",

--- a/scripts/check-cinematic-markers.mjs
+++ b/scripts/check-cinematic-markers.mjs
@@ -45,13 +45,16 @@ const SOURCE_CHECKS = [
     ],
   },
   {
-    id: "story-cards-not-sticky",
-    path: "src/components/StoryArc.tsx",
+    id: "story-era-art",
+    path: "src/lib/story-surface.ts",
     patterns: [
       /era-web\.jpg|era-social\.jpg|era-mobile\.jpg|era-ai\.jpg|era-consulting\.jpg/,
-      /EraCard/,
-      /from-surface via-surface/,
     ],
+  },
+  {
+    id: "story-cards-not-sticky",
+    path: "src/components/StoryArc.tsx",
+    patterns: [/EraCard/, /from-surface via-surface/],
   },
   {
     id: "hero-art-asset",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,7 @@ import "./globals.css";
 import AppShell from "@/components/layout/AppShell";
 import { SECTIONS } from "@/config/sections";
 import { NavigationProvider } from "@/context/NavigationContext";
-import { PERSONAL_INFO } from "@/data/personal";
+import { PERSONAL_INFO, SITE_DESCRIPTION } from "@/data/personal";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -36,7 +36,7 @@ const jetbrainsMono = JetBrains_Mono({
 
 const fullName = `${PERSONAL_INFO.firstName} ${PERSONAL_INFO.lastName}`;
 const TITLE = `${fullName} — AI infrastructure builder`;
-const DESCRIPTION = `${fullName} builds the infrastructure AI agents run on — MCP servers and AI-native developer tools, including pdf-reader-mcp; building Sylphx (AI-native PaaS) plus RAG and semantic-search tooling. 20 years shipping software before this: 10M+ app downloads, 10M+ monthly players.`;
+const DESCRIPTION = SITE_DESCRIPTION;
 
 export const viewport: Viewport = {
   width: "device-width",

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -5,10 +5,11 @@ import { FaArrowRight, FaBolt, FaGithub } from "react-icons/fa6";
 import { useNavigationStore } from "@/context/NavigationContext";
 import { type HighlightKind, useWorkGraph } from "@/context/WorkGraphContext";
 import { PERSONAL_INFO } from "@/data/personal";
-import { useCountUp } from "@/hooks/useCountUp";
+import { heroProofBoard } from "@/lib/hero-proof-board";
 import { proofBoardDotClass, proofBoardObservation } from "@/lib/proof-board";
-import { BAKED_STATS, HERO_PROOF } from "@/lib/stats";
-import { compact, timeAgo } from "@/lib/terminal";
+import { BAKED_STATS } from "@/lib/stats";
+import { timeAgo } from "@/lib/terminal";
+import { HeroProofGrid } from "./HeroProofGrid";
 import LiveTicker from "./LiveTicker";
 
 /**
@@ -38,18 +39,7 @@ export default function Hero() {
           },
         };
 
-  const stars = stats
-    ? compact(stats.githubStars)
-    : HERO_PROOF.githubStars.display;
-  const downloads = stats
-    ? compact(stats.npmDownloads)
-    : HERO_PROOF.npmDownloads.display;
-  const flagStars = stats
-    ? compact(stats.flagshipStars)
-    : HERO_PROOF.flagshipStars.display;
-  const flagDl = stats
-    ? compact(stats.flagshipDownloads)
-    : HERO_PROOF.flagshipDownloads.display;
+  const cells = heroProofBoard(stats);
   const lastShip = recent[0];
   const board = proofBoardObservation({
     live,
@@ -193,39 +183,11 @@ export default function Hero() {
               </span>
             </div>
 
-            <div className="grid grid-cols-2 gap-px bg-border-subtle">
-              <ProofNode
-                label="GitHub stars"
-                value={stars}
-                suffix="★"
-                kind="stars"
-                hint="across all repos"
-                onHover={setHighlight}
-                onClick={jump}
-                numeric={stats?.githubStars}
-              />
-              <ProofNode
-                label="npm downloads"
-                value={downloads}
-                suffix="/mo"
-                kind="downloads"
-                hint="across packages"
-                onHover={setHighlight}
-                onClick={jump}
-                numeric={stats?.npmDownloads}
-              />
-              <ProofNode
-                label="pdf-reader-mcp"
-                value={flagStars}
-                suffix="★"
-                kind="flagship"
-                hint={`${flagDl}/mo · the flagship`}
-                onHover={setHighlight}
-                onClick={jump}
-                wide
-                numeric={stats?.flagshipStars}
-              />
-            </div>
+            <HeroProofGrid
+              cells={cells}
+              onHover={setHighlight}
+              onClick={jump}
+            />
 
             <button
               type="button"
@@ -255,52 +217,5 @@ export default function Hero() {
         </motion.div>
       </div>
     </section>
-  );
-}
-
-function ProofNode({
-  label,
-  value,
-  suffix,
-  kind,
-  hint,
-  onHover,
-  onClick,
-  wide,
-  numeric,
-}: {
-  label: string;
-  value: string;
-  suffix: string;
-  kind: HighlightKind;
-  hint: string;
-  onHover: (h: HighlightKind) => void;
-  onClick: (h: HighlightKind) => void;
-  wide?: boolean;
-  numeric?: number;
-}) {
-  const animated = useCountUp(numeric ?? 0, 1400, true);
-  const display = numeric ? animated.toLocaleString() : value;
-  return (
-    <button
-      type="button"
-      onMouseEnter={() => onHover(kind)}
-      onMouseLeave={() => onHover(null)}
-      onFocus={() => onHover(kind)}
-      onBlur={() => onHover(null)}
-      onClick={() => onClick(kind)}
-      className={`group bg-surface/70 px-4 py-4 text-left transition-colors hover:bg-accent-subtle/50 ${wide ? "col-span-2" : ""}`}
-    >
-      <div className="flex items-baseline gap-1 font-mono text-xl font-semibold tracking-tight text-text-primary tabular-nums transition-colors group-hover:text-accent sm:text-2xl">
-        {display}
-        <span className="text-sm text-text-tertiary group-hover:text-accent">
-          {suffix}
-        </span>
-      </div>
-      <div className="mt-1 text-xs text-text-tertiary">{label}</div>
-      <div className="mt-0.5 font-mono text-[10.5px] text-text-tertiary/70 group-hover:text-text-secondary">
-        {hint}
-      </div>
-    </button>
   );
 }

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -7,7 +7,7 @@ import { type HighlightKind, useWorkGraph } from "@/context/WorkGraphContext";
 import { PERSONAL_INFO } from "@/data/personal";
 import { useCountUp } from "@/hooks/useCountUp";
 import { proofBoardDotClass, proofBoardObservation } from "@/lib/proof-board";
-import { BAKED_STATS, STATS } from "@/lib/stats";
+import { BAKED_STATS, HERO_PROOF } from "@/lib/stats";
 import { compact, timeAgo } from "@/lib/terminal";
 import LiveTicker from "./LiveTicker";
 
@@ -38,16 +38,18 @@ export default function Hero() {
           },
         };
 
-  const stars = stats ? compact(stats.githubStars) : STATS.githubStars.display;
+  const stars = stats
+    ? compact(stats.githubStars)
+    : HERO_PROOF.githubStars.display;
   const downloads = stats
     ? compact(stats.npmDownloads)
-    : STATS.npmDownloads.display;
+    : HERO_PROOF.npmDownloads.display;
   const flagStars = stats
     ? compact(stats.flagshipStars)
-    : STATS.flagshipStars.display;
+    : HERO_PROOF.flagshipStars.display;
   const flagDl = stats
     ? compact(stats.flagshipDownloads)
-    : STATS.flagshipDownloads.display;
+    : HERO_PROOF.flagshipDownloads.display;
   const lastShip = recent[0];
   const board = proofBoardObservation({
     live,
@@ -114,8 +116,8 @@ export default function Hero() {
           >
             Open-source MCP servers and AI-native developer tools, plus{" "}
             <strong className="font-semibold text-text-primary">Sylphx</strong>{" "}
-            — an AI-native PaaS with its own AI Gateway. Twenty years shipping
-            before this; 10M+ app downloads at a Hong Kong gaming studio.
+            — an AI-native PaaS with its own AI Gateway. Career since 2006 is on
+            Story as self-attested history, not live GitHub/npm.
           </motion.p>
 
           <motion.div {...rise(0.16)} className="mt-5">
@@ -242,10 +244,7 @@ export default function Hero() {
                     {timeAgo(lastShip.pushedAt)}
                   </>
                 ) : (
-                  <>
-                    actively shipping —{" "}
-                    {STATS.yearsExperience?.display ?? "20+"} years building
-                  </>
+                  <>actively shipping — live GitHub activity on this board</>
                 )}
               </span>
             </button>

--- a/src/components/HeroProofGrid.tsx
+++ b/src/components/HeroProofGrid.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import type { HighlightKind } from "@/context/WorkGraphContext";
+import { useCountUp } from "@/hooks/useCountUp";
+import type { HeroProofCell } from "@/lib/hero-proof-board";
+
+/**
+ * Exact proof-board grid Hero renders. Extra cells belong here — the
+ * honesty oracle renders this component, not a parallel unused array.
+ */
+export function HeroProofGrid({
+  cells,
+  onHover,
+  onClick,
+}: {
+  cells: HeroProofCell[];
+  onHover: (h: HighlightKind) => void;
+  onClick: (h: HighlightKind) => void;
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-px bg-border-subtle">
+      {cells.map((cell) => (
+        <ProofNode
+          key={cell.id}
+          label={cell.label}
+          value={cell.display}
+          suffix={cell.suffix}
+          kind={cell.kind}
+          hint={cell.hint}
+          onHover={onHover}
+          onClick={onClick}
+          wide={cell.wide}
+          numeric={cell.numeric}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ProofNode({
+  label,
+  value,
+  suffix,
+  kind,
+  hint,
+  onHover,
+  onClick,
+  wide,
+  numeric,
+}: {
+  label: string;
+  value: string;
+  suffix: string;
+  kind: HighlightKind;
+  hint: string;
+  onHover: (h: HighlightKind) => void;
+  onClick: (h: HighlightKind) => void;
+  wide?: boolean;
+  numeric?: number;
+}) {
+  const animated = useCountUp(numeric ?? 0, 1400, true);
+  const display = numeric ? animated.toLocaleString() : value;
+  return (
+    <button
+      type="button"
+      onMouseEnter={() => onHover(kind)}
+      onMouseLeave={() => onHover(null)}
+      onFocus={() => onHover(kind)}
+      onBlur={() => onHover(null)}
+      onClick={() => onClick(kind)}
+      className={`group bg-surface/70 px-4 py-4 text-left transition-colors hover:bg-accent-subtle/50 ${wide ? "col-span-2" : ""}`}
+    >
+      <div className="flex items-baseline gap-1 font-mono text-xl font-semibold tracking-tight text-text-primary tabular-nums transition-colors group-hover:text-accent sm:text-2xl">
+        {display}
+        <span className="text-sm text-text-tertiary group-hover:text-accent">
+          {suffix}
+        </span>
+      </div>
+      <div className="mt-1 text-xs text-text-tertiary">{label}</div>
+      <div className="mt-0.5 font-mono text-[10.5px] text-text-tertiary/70 group-hover:text-text-secondary">
+        {hint}
+      </div>
+    </button>
+  );
+}

--- a/src/components/StoryArc.tsx
+++ b/src/components/StoryArc.tsx
@@ -14,6 +14,11 @@ import {
 } from "@/data/roles";
 import type { Organization, Role } from "@/data/types";
 import { useCountUp } from "@/hooks/useCountUp";
+import {
+  careerScaleCaption,
+  SELF_ATTESTED_HISTORICAL,
+  STORY_SCALE_HEADLINES,
+} from "@/lib/claim-honesty";
 import CompanyLogo from "./CompanyLogo";
 import Reveal from "./ui/Reveal";
 import SectionHeader from "./ui/SectionHeader";
@@ -55,13 +60,13 @@ const ERA_META: Record<
   },
   "minimax-ceo": {
     era: "Social Gaming",
-    headline: "Facebook games at 10M scale",
+    headline: STORY_SCALE_HEADLINES["minimax-ceo"],
     image: "/art/era-social.jpg",
     imageAlt: "Ambient visual derived from MiniMax / Funimax social games",
   },
   "cubeage-founder": {
     era: "Mobile Gaming",
-    headline: "25+ games, 10M downloads",
+    headline: STORY_SCALE_HEADLINES["cubeage-founder"],
     image: "/art/era-mobile.jpg",
     imageAlt: "Ambient visual derived from Cubeage mobile game products",
   },
@@ -153,7 +158,7 @@ export default function StoryArc() {
         index="01"
         eyebrow="The journey"
         title="Twenty years. Five eras. One builder."
-        description="From a Hong Kong gaming forum in 2006 to AI infrastructure today — every chapter proved Kyle can ship and scale. Companies are chapters of the same proof, not a second product."
+        description="From a Hong Kong gaming forum in 2006 to AI infrastructure today. Scale figures in this section are self-attested historical pedigree — not live GitHub/npm instruments. Companies are chapters of the same career, not a second product catalog."
       />
 
       <Reveal delay={0.05}>
@@ -211,6 +216,9 @@ export default function StoryArc() {
           </div>
           <div className="font-mono text-xs uppercase tracking-[0.2em] text-text-tertiary">
             years of building
+          </div>
+          <div className="font-mono text-[10px] text-text-tertiary">
+            {SELF_ATTESTED_HISTORICAL}
           </div>
         </div>
       </Reveal>
@@ -288,7 +296,7 @@ function EraCard({
           {scaleNumber && (
             <AnimatedScale
               value={scaleNumber.value}
-              label={scaleNumber.label}
+              label={careerScaleCaption(scaleNumber.label)}
             />
           )}
 

--- a/src/components/StoryArc.tsx
+++ b/src/components/StoryArc.tsx
@@ -5,20 +5,20 @@ import Image from "next/image";
 import { useEffect, useId, useState } from "react";
 import { FaArrowUpRightFromSquare, FaGithub, FaXmark } from "react-icons/fa6";
 import { useWorkGraph } from "@/context/WorkGraphContext";
-import { formatNumber } from "@/data";
 import { getOrganization, ORGANIZATIONS } from "@/data/organizations";
 import {
   calculateTotalExperience,
   getRolesByOrganization,
   getRolesSortedByDate,
 } from "@/data/roles";
-import type { Organization, Role } from "@/data/types";
+import type { Organization } from "@/data/types";
 import { useCountUp } from "@/hooks/useCountUp";
 import {
-  careerScaleCaption,
-  SELF_ATTESTED_HISTORICAL,
-  STORY_SCALE_HEADLINES,
-} from "@/lib/claim-honesty";
+  type EraChapter,
+  STORY_SECTION,
+  storyChapters,
+  storyYears,
+} from "@/lib/story-surface";
 import CompanyLogo from "./CompanyLogo";
 import Reveal from "./ui/Reveal";
 import SectionHeader from "./ui/SectionHeader";
@@ -29,112 +29,15 @@ import SectionHeader from "./ui/SectionHeader";
  * Achievements come from roles, not a second project catalog.
  */
 
-interface EraChapter {
-  role: Role;
-  era: string;
-  startYear: string;
-  headline: string;
-  image: string;
-  imageAlt: string;
-  scaleNumber?: { value: number; label: string; display: string };
-  projects?: string[];
-}
-
-function eraProofPoints(role: Role): string[] {
-  const fromAchievements = role.keyAchievements?.slice(0, 5) ?? [];
-  if (fromAchievements.length > 0) return fromAchievements;
-  return (role.responsibilities ?? []).slice(0, 4);
-}
-
 const ORG_ORDER = ["sylphx", "epiow", "cubeage", "minimax", "nakuz"] as const;
-
-const ERA_META: Record<
-  string,
-  { era: string; headline: string; image: string; imageAlt: string }
-> = {
-  "nakuz-cto": {
-    era: "Web · Community",
-    headline: "Hong Kong's gaming portal",
-    image: "/art/era-web.jpg",
-    imageAlt: "Ambient visual derived from Nakuz brand and portal materials",
-  },
-  "minimax-ceo": {
-    era: "Social Gaming",
-    headline: STORY_SCALE_HEADLINES["minimax-ceo"],
-    image: "/art/era-social.jpg",
-    imageAlt: "Ambient visual derived from MiniMax / Funimax social games",
-  },
-  "cubeage-founder": {
-    era: "Mobile Gaming",
-    headline: STORY_SCALE_HEADLINES["cubeage-founder"],
-    image: "/art/era-mobile.jpg",
-    imageAlt: "Ambient visual derived from Cubeage mobile game products",
-  },
-  "epiow-cto": {
-    era: "Enterprise · Platform",
-    headline: "Organization operating system",
-    // cache-bust: ambient was regenerated from official E-Orbit mark
-    image: "/art/era-consulting.jpg?v=eorbit2",
-    imageAlt:
-      "Ambient visual derived from the official Epiow E-Orbit brand mark",
-  },
-  "sylphx-founder": {
-    era: "AI · Open Source",
-    headline: "The infrastructure AI agents run on",
-    image: "/art/era-ai.jpg",
-    imageAlt:
-      "Ambient visual derived from Sylphx brand mark and AI platform identity",
-  },
-};
-
-function getScaleNumber(
-  role: Role,
-): { value: number; label: string; display: string } | undefined {
-  if (!role.metrics.length) return undefined;
-  const m = role.metrics.reduce((best, cur) => {
-    if (typeof cur.value !== "number") return best;
-    if (!best || typeof best.value !== "number" || cur.value > best.value)
-      return cur;
-    return best;
-  });
-  if (typeof m.value !== "number" || m.value < 1000) return undefined;
-  return {
-    value: m.value,
-    label:
-      m.label ||
-      m.unit ||
-      (m.type === "downloads"
-        ? "Downloads"
-        : m.type === "users"
-          ? "Users"
-          : "Scale"),
-    display: formatNumber(m.value),
-  };
-}
 
 export default function StoryArc() {
   const reduce = useReducedMotion();
   const roles = getRolesSortedByDate();
-  const years = calculateTotalExperience();
+  const years = storyYears(calculateTotalExperience());
   const { ask } = useWorkGraph();
   const [orgId, setOrgId] = useState<string | null>(null);
-
-  const chapters: EraChapter[] = roles
-    .map((role) => {
-      const meta = ERA_META[role.id];
-      if (!meta) return null;
-      return {
-        role,
-        era: meta.era,
-        startYear: role.period.start.substring(0, 4),
-        headline: meta.headline,
-        image: meta.image,
-        imageAlt: meta.imageAlt,
-        scaleNumber: getScaleNumber(role),
-        projects: eraProofPoints(role),
-      };
-    })
-    .filter(Boolean) as EraChapter[];
+  const chapters = storyChapters(roles);
 
   const orgs = ORG_ORDER.map((id) => ORGANIZATIONS[id]).filter(Boolean);
   const selectedOrg = orgId ? ORGANIZATIONS[orgId] : null;
@@ -155,10 +58,10 @@ export default function StoryArc() {
   return (
     <div className="container-wide">
       <SectionHeader
-        index="01"
-        eyebrow="The journey"
-        title="Twenty years. Five eras. One builder."
-        description="From a Hong Kong gaming forum in 2006 to AI infrastructure today. Scale figures in this section are self-attested historical pedigree — not live GitHub/npm instruments. Companies are chapters of the same career, not a second product catalog."
+        index={STORY_SECTION.index}
+        eyebrow={STORY_SECTION.eyebrow}
+        title={STORY_SECTION.title}
+        description={STORY_SECTION.description}
       />
 
       <Reveal delay={0.05}>
@@ -212,13 +115,13 @@ export default function StoryArc() {
       <Reveal>
         <div className="mt-14 flex flex-col items-center gap-1.5 py-8 text-center">
           <div className="font-display text-4xl font-semibold tracking-tight text-accent sm:text-5xl">
-            {years}+
+            {years.display}
           </div>
           <div className="font-mono text-xs uppercase tracking-[0.2em] text-text-tertiary">
-            years of building
+            {years.label}
           </div>
           <div className="font-mono text-[10px] text-text-tertiary">
-            {SELF_ATTESTED_HISTORICAL}
+            {years.caption}
           </div>
         </div>
       </Reveal>
@@ -296,7 +199,7 @@ function EraCard({
           {scaleNumber && (
             <AnimatedScale
               value={scaleNumber.value}
-              label={careerScaleCaption(scaleNumber.label)}
+              label={scaleNumber.caption}
             />
           )}
 

--- a/src/data/organizations.ts
+++ b/src/data/organizations.ts
@@ -43,7 +43,7 @@ export const ORGANIZATIONS: Record<string, Organization> = {
     type: "company",
     status: "active",
     description:
-      "Mobile gaming company — card and casino games with 10M+ downloads",
+      "Mobile gaming company — card and casino games. Download scale is self-attested historical pedigree.",
     logo: "/company/cubeage.jpeg",
     website: "https://cubeage.com",
     github: "Cubeage",
@@ -59,7 +59,7 @@ export const ORGANIZATIONS: Record<string, Organization> = {
     type: "company",
     status: "active",
     description:
-      "Hong Kong gaming media platform and community with 500K+ users",
+      "Hong Kong gaming media platform and community. User scale is self-attested historical pedigree.",
     logo: "/company/nakuz.jpeg",
     website: "https://nakuz.com",
     location: "Hong Kong",
@@ -91,7 +91,8 @@ export const ORGANIZATIONS: Record<string, Organization> = {
     tradingName: "Funimax",
     type: "company",
     status: "closed",
-    description: "Social gaming company — Facebook games with 10M+ MAU",
+    description:
+      "Social gaming company — Facebook games. MAU scale is self-attested historical pedigree.",
     logo: "/company/minimax.jpeg",
     website: "https://funimax.com",
     location: "Hong Kong",

--- a/src/data/personal.ts
+++ b/src/data/personal.ts
@@ -5,7 +5,7 @@ export const PERSONAL_INFO: PersonalInfo = {
   lastName: "Tse",
   title: "AI Infrastructure Builder",
   shortBio:
-    "I build the infrastructure AI agents run on — MCP servers and AI-native developer tools. My PDF reader for AI agents has thousands of GitHub stars and tens of thousands of monthly npm downloads; I'm building Sylphx, an AI-native PaaS, plus RAG and semantic-search tooling. 20 years shipping software before this: 10M+ mobile-game downloads (Cubeage), 10M+ monthly players (MiniMax), and Hong Kong's leading gaming portal (Nakuz).",
+    "I build the infrastructure AI agents run on — MCP servers and AI-native developer tools. Flagship pdf-reader-mcp and live GitHub/npm figures are instruments on this site. Career since 2006 (Nakuz, MiniMax, Cubeage, Epiow, Sylphx) is on Story as self-attested historical pedigree, not live GitHub/npm.",
   email: "hi@kylet.se",
   location: {
     base: "London, UK",
@@ -16,13 +16,6 @@ export const PERSONAL_INFO: PersonalInfo = {
     linkedin: "https://linkedin.com/in/shtse8",
     stackoverflow: "https://stackoverflow.com/users/4380384/shtse8",
   },
-  contactFormSubjects: [
-    "Project Inquiry",
-    "Job Opportunity",
-    "Consultation Request",
-    "Open Source Collaboration",
-    "Other",
-  ],
   portfolioUrl: "https://kylet.se",
   company: "Sylphx",
   specialties: [
@@ -33,7 +26,7 @@ export const PERSONAL_INFO: PersonalInfo = {
     "Developer Tools & DX",
     "System Architecture",
     "Full Stack Development",
-    "Shipping at Scale (10M+ users)",
+    "Shipping at scale (self-attested Cubeage / MiniMax pedigree)",
   ],
   tagline:
     "Building the infrastructure AI agents run on — MCP servers & AI-native developer tools",
@@ -45,3 +38,5 @@ export const PERSONAL_INFO: PersonalInfo = {
     "Technical Founder",
   ],
 } as const;
+
+export const SITE_DESCRIPTION = `${PERSONAL_INFO.firstName} ${PERSONAL_INFO.lastName} builds the infrastructure AI agents run on — MCP servers and AI-native developer tools, including pdf-reader-mcp, plus Sylphx (AI-native PaaS). Live GitHub/npm proof on kylet.se; career history on /story (self-attested historical pedigree).`;

--- a/src/data/roles.ts
+++ b/src/data/roles.ts
@@ -1,3 +1,4 @@
+import { SELF_ATTESTED_HISTORICAL } from "@/lib/claim-honesty";
 import type { Role } from "./types";
 
 /**
@@ -76,11 +77,10 @@ export const ROLES: Role[] = [
     type: "founder",
     period: { start: "2014-01" },
     location: "Hong Kong / China",
-    description:
-      "Founded and led all technical development for mobile gaming company achieving 10M+ global downloads",
+    description: `Founded and led all technical development for mobile gaming company achieving 10M+ global downloads (${SELF_ATTESTED_HISTORICAL})`,
     responsibilities: [
       "Developed and operated mobile games across multiple genres at Cubeage Limited",
-      "Achieved over 10 million total installs across global markets including China, Hong Kong, Taiwan and Southeast Asia",
+      `Achieved over 10 million total installs across global markets including China, Hong Kong, Taiwan and Southeast Asia (${SELF_ATTESTED_HISTORICAL})`,
       "Built games using various frameworks including Unity3D, Cocos2d, Corona SDK and Flutter to optimize for different platforms and requirements",
       "Implemented comprehensive backend infrastructure to support large-scale multiplayer games",
       "Worked with development teams across Hong Kong and China offices",
@@ -88,12 +88,19 @@ export const ROLES: Role[] = [
       "Managed full game lifecycle from concept to live operations and updates",
     ],
     keyAchievements: [
-      "Reached 10M+ global downloads",
+      `Reached 10M+ global downloads (${SELF_ATTESTED_HISTORICAL})`,
       "Successfully launched in multiple markets",
       "Built scalable multi-region infrastructure",
     ],
     metrics: [
-      { type: "downloads", value: 10000000, context: "total" },
+      {
+        type: "downloads",
+        value: 10000000,
+        context: "total",
+        honesty: "self-attested",
+        verified: false,
+        source: SELF_ATTESTED_HISTORICAL,
+      },
       { type: "projects", value: 4, unit: "Game Frameworks" },
       { type: "custom", value: 2, unit: "Regional Offices" },
     ],
@@ -117,25 +124,31 @@ export const ROLES: Role[] = [
     type: "cofounder",
     period: { start: "2010-01", end: "2016-12" },
     location: "Hong Kong / Taiwan / China",
-    description:
-      "Co-founded social gaming company that reached 10M+ monthly active users on Facebook",
+    description: `Co-founded social gaming company that reached 10M+ monthly active users on Facebook (${SELF_ATTESTED_HISTORICAL})`,
     responsibilities: [
       "Co-founded MiniMax Game Entertainment Limited, a social gaming company with offices in Hong Kong, Taiwan and China",
       "Built and operated over 30 concurrent social games and apps on Facebook platform",
-      "Achieved over 10 million monthly active users (MAU) across portfolio of social games",
+      `Achieved over 10 million monthly active users (MAU) across portfolio of social games (${SELF_ATTESTED_HISTORICAL})`,
       "Became a notable Facebook game developer in Hong Kong and Taiwan markets",
       "Worked on Funimax platform, a major game distribution service with extensive retail network",
       "Participated in multi-region game operations, distribution partnerships and agency relationships",
       "Implemented comprehensive payment and analytics systems across physical and digital channels",
-      "Built scalable infrastructure to support millions of daily active users",
+      `Built scalable infrastructure to support millions of daily active users (${SELF_ATTESTED_HISTORICAL})`,
     ],
     keyAchievements: [
-      "Reached 10M+ monthly active users",
+      `Reached 10M+ monthly active users (${SELF_ATTESTED_HISTORICAL})`,
       "Operated 30+ concurrent games",
       "Top Facebook game developer in HK",
     ],
     metrics: [
-      { type: "users", value: 10000000, context: "monthly" },
+      {
+        type: "users",
+        value: 10000000,
+        context: "monthly",
+        honesty: "self-attested",
+        verified: false,
+        source: SELF_ATTESTED_HISTORICAL,
+      },
       { type: "projects", value: 30, unit: "Active Games" },
       { type: "custom", value: 3, unit: "Regional Offices" },
     ],
@@ -157,11 +170,10 @@ export const ROLES: Role[] = [
     type: "cofounder",
     period: { start: "2006-01" },
     location: "Hong Kong",
-    description:
-      "Co-founded and built a Hong Kong gaming media platform with 500K+ registered users",
+    description: `Co-founded and built a Hong Kong gaming media platform with 500K+ registered users (${SELF_ATTESTED_HISTORICAL})`,
     responsibilities: [
       "Built and maintained a popular Hong Kong gaming information platform powered by Discuz!, PHP, MySQL and Ubuntu",
-      "Grew to over 500,000 registered users and 3,000+ concurrent online users",
+      `Grew to over 500,000 registered users and 3,000+ concurrent online users (${SELF_ATTESTED_HISTORICAL})`,
       "Established as the official discussion platform for 100+ game publishers and developers",
       "Achieved strong rankings in Hong Kong gaming media",
       "Created comprehensive game guides, news coverage and community features",
@@ -169,13 +181,27 @@ export const ROLES: Role[] = [
       "Built strong partnerships with major gaming companies across Asia",
     ],
     keyAchievements: [
-      "500K+ Registered Users",
+      `500K+ Registered Users (${SELF_ATTESTED_HISTORICAL})`,
       "100+ Official Game Partnerships",
-      "3K+ Concurrent Users",
+      `3K+ Concurrent Users (${SELF_ATTESTED_HISTORICAL})`,
     ],
     metrics: [
-      { type: "users", value: 500000, context: "total" },
-      { type: "users", value: 3000, context: "concurrent" },
+      {
+        type: "users",
+        value: 500000,
+        context: "total",
+        honesty: "self-attested",
+        verified: false,
+        source: SELF_ATTESTED_HISTORICAL,
+      },
+      {
+        type: "users",
+        value: 3000,
+        context: "concurrent",
+        honesty: "self-attested",
+        verified: false,
+        source: SELF_ATTESTED_HISTORICAL,
+      },
       { type: "partners", value: 100, unit: "Game Partners" },
     ],
     skills: [

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -13,6 +13,8 @@ export type Period = {
 /**
  * Metric for quantifiable achievements
  */
+export type MetricHonesty = "live-measured" | "self-attested";
+
 export type Metric = {
   type:
     | "users"
@@ -29,6 +31,8 @@ export type Metric = {
   context?: "monthly" | "total" | "peak" | "daily" | "concurrent";
   verified?: boolean;
   source?: string;
+  /** Career-scale metrics are self-attested historical pedigree. */
+  honesty?: MetricHonesty;
 };
 
 // ========================================
@@ -114,7 +118,6 @@ export type PersonalInfo = {
     linkedin: string;
     stackoverflow: string;
   };
-  contactFormSubjects: string[];
   portfolioUrl: string;
   company: string;
   specialties?: string[];

--- a/src/lib/claim-honesty.test.ts
+++ b/src/lib/claim-honesty.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+import { PERSONAL_INFO, SITE_DESCRIPTION } from "@/data/personal";
+import { ROLES } from "@/data/roles";
+import manifest from "../../public/manifest.json";
+import {
+  CAREER_PEDIGREE_IDS,
+  careerScaleCaption,
+  LIVE_INSTRUMENT_IDS,
+  SELF_ATTESTED_HISTORICAL,
+  STORY_SCALE_HEADLINES,
+} from "./claim-honesty";
+import { HERO_PROOF, HERO_STATS, STATS } from "./stats";
+
+describe("claim honesty", () => {
+  test("hero proof instruments are live-measured GitHub/npm only", () => {
+    expect(HERO_STATS).toEqual([
+      HERO_PROOF.githubStars,
+      HERO_PROOF.npmDownloads,
+      HERO_PROOF.flagshipStars,
+      HERO_PROOF.flagshipDownloads,
+    ]);
+    expect(HERO_STATS.length).toBeGreaterThan(0);
+    for (const stat of HERO_STATS) {
+      expect(stat.honesty).toBe("live-measured");
+    }
+    const heroIds = HERO_STATS.map((s) => s.id);
+    expect(heroIds).not.toContain("downloads");
+    expect(heroIds).not.toContain("players");
+    expect(heroIds).not.toContain("years");
+  });
+
+  test("named live instrument stats are live-measured", () => {
+    for (const id of LIVE_INSTRUMENT_IDS) {
+      expect(STATS[id].honesty).toBe("live-measured");
+    }
+  });
+
+  test("career pedigree stats are self-attested and not live", () => {
+    for (const id of CAREER_PEDIGREE_IDS) {
+      expect(STATS[id].honesty).toBe("self-attested");
+    }
+  });
+
+  test("role scale metrics are self-attested historical, never verified-live", () => {
+    let scale = 0;
+    for (const role of ROLES) {
+      for (const metric of role.metrics) {
+        if (typeof metric.value === "number" && metric.value >= 1000) {
+          scale += 1;
+          expect(metric.honesty).toBe("self-attested");
+          expect(metric.verified).not.toBe(true);
+          expect(metric.source).toBe(SELF_ATTESTED_HISTORICAL);
+        }
+      }
+    }
+    expect(scale).toBeGreaterThan(0);
+  });
+
+  test("career scale caption never uses live freshness vocabulary", () => {
+    const caption = careerScaleCaption("Downloads");
+    expect(caption).toContain(SELF_ATTESTED_HISTORICAL);
+    expect(caption.toLowerCase()).not.toMatch(/\bfreshness\b/);
+    expect(caption.toLowerCase()).not.toMatch(/\bfreshness=live\b/);
+  });
+
+  test("story headlines that include career scale are labeled pedigree", () => {
+    expect(STORY_SCALE_HEADLINES["minimax-ceo"]).toContain("10M");
+    expect(STORY_SCALE_HEADLINES["cubeage-founder"]).toContain("10M");
+    for (const headline of Object.values(STORY_SCALE_HEADLINES)) {
+      expect(headline).toContain(SELF_ATTESTED_HISTORICAL);
+      expect(headline.toLowerCase()).not.toContain("freshness=live");
+    }
+  });
+
+  test("personal info has no contact form", () => {
+    expect(Object.hasOwn(PERSONAL_INFO, "contactFormSubjects")).toBe(false);
+  });
+
+  test("site description and short bio do not present 10M+ as a live instrument", () => {
+    const bio = PERSONAL_INFO.shortBio.toLowerCase();
+    const desc = SITE_DESCRIPTION.toLowerCase();
+    expect(bio).not.toContain("10m");
+    expect(desc).not.toContain("10m");
+    expect(bio).toContain("self-attested");
+    expect(desc).toContain("self-attested");
+    expect(bio).not.toContain("freshness=live");
+    expect(desc).not.toContain("freshness=live");
+  });
+
+  test("visitor-visible role copy that names career-scale figures is labeled pedigree", () => {
+    const blobs: string[] = [];
+    for (const role of ROLES) {
+      blobs.push(role.description);
+      blobs.push(...role.responsibilities);
+      blobs.push(...(role.keyAchievements ?? []));
+    }
+    const scale = blobs.filter((s) =>
+      /10m|\bmillion|\b500k\b|\b500,000\b|\b3k\+|\b3,000\+/i.test(s),
+    );
+    expect(scale.length).toBeGreaterThan(0);
+    for (const line of scale) {
+      expect(line).toContain(SELF_ATTESTED_HISTORICAL);
+      expect(line.toLowerCase()).not.toContain("freshness=live");
+    }
+  });
+
+  test("PWA manifest does not present unlabeled career-scale figures", () => {
+    const desc = manifest.description.toLowerCase();
+    expect(desc).not.toContain("10m");
+    expect(desc).not.toMatch(/\b20 years\b/);
+    expect(desc).toContain("self-attested");
+    expect(desc).not.toContain("freshness=live");
+  });
+});

--- a/src/lib/claim-honesty.test.ts
+++ b/src/lib/claim-honesty.test.ts
@@ -1,68 +1,113 @@
 import { describe, expect, test } from "bun:test";
-import { PERSONAL_INFO, SITE_DESCRIPTION } from "@/data/personal";
-import { ROLES } from "@/data/roles";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { HeroProofGrid } from "@/components/HeroProofGrid";
+import { SITE_DESCRIPTION } from "@/data/personal";
+import {
+  calculateTotalExperience,
+  getRolesSortedByDate,
+  ROLES,
+} from "@/data/roles";
+import type { TermStats } from "@/lib/terminal";
 import manifest from "../../public/manifest.json";
 import {
-  CAREER_PEDIGREE_IDS,
-  careerScaleCaption,
-  LIVE_INSTRUMENT_IDS,
   SELF_ATTESTED_HISTORICAL,
   STORY_SCALE_HEADLINES,
 } from "./claim-honesty";
-import { HERO_PROOF, HERO_STATS, STATS } from "./stats";
+import {
+  careerScaleInHeroMarkup,
+  careerScaleOnHeroBoard,
+  type HeroProofCell,
+  heroProofBoard,
+} from "./hero-proof-board";
+import { STATS } from "./stats";
+import {
+  STORY_SECTION,
+  storyCareerVisitorCopy,
+  storyChapters,
+  storyCopyBorrowsLiveFreshness,
+  storyYears,
+  unlabeledStoryScale,
+} from "./story-surface";
 
-describe("claim honesty", () => {
-  test("hero proof instruments are live-measured GitHub/npm only", () => {
-    expect(HERO_STATS).toEqual([
-      HERO_PROOF.githubStars,
-      HERO_PROOF.npmDownloads,
-      HERO_PROOF.flagshipStars,
-      HERO_PROOF.flagshipDownloads,
-    ]);
-    expect(HERO_STATS.length).toBeGreaterThan(0);
-    for (const stat of HERO_STATS) {
-      expect(stat.honesty).toBe("live-measured");
+const noop = () => {};
+
+const LIVE_STATS: TermStats = {
+  githubStars: 12,
+  npmDownloads: 34,
+  flagshipStars: 56,
+  flagshipDownloads: 78,
+  byOwner: {},
+  repos: 3,
+  updatedAt: "2026-09-05T14:00:00Z",
+  freshness: "live",
+};
+
+function renderBoard(cells: HeroProofCell[]): string {
+  return renderToStaticMarkup(
+    createElement(HeroProofGrid, {
+      cells,
+      onHover: noop,
+      onClick: noop,
+    }),
+  );
+}
+
+describe("hero proof board (owning writer)", () => {
+  test("unlabeled career-scale numbers do not share the hero proof board", () => {
+    for (const stats of [null, LIVE_STATS] as const) {
+      const cells = heroProofBoard(stats);
+      expect(careerScaleOnHeroBoard(cells)).toEqual([]);
+      expect(careerScaleInHeroMarkup(renderBoard(cells))).toEqual([]);
     }
-    const heroIds = HERO_STATS.map((s) => s.id);
-    expect(heroIds).not.toContain("downloads");
-    expect(heroIds).not.toContain("players");
-    expect(heroIds).not.toContain("years");
   });
 
-  test("named live instrument stats are live-measured", () => {
-    for (const id of LIVE_INSTRUMENT_IDS) {
-      expect(STATS[id].honesty).toBe("live-measured");
-    }
+  test("oracle goes red when a career-scale cell is planted on the board", () => {
+    const planted: HeroProofCell[] = [
+      ...heroProofBoard(null),
+      {
+        id: STATS.appDownloads.id,
+        label: STATS.appDownloads.label,
+        display: STATS.appDownloads.display,
+        suffix: "",
+        kind: "downloads",
+        hint: "",
+      },
+    ];
+    expect(careerScaleOnHeroBoard(planted).length).toBeGreaterThan(0);
+    expect(careerScaleInHeroMarkup(renderBoard(planted))).toContain(
+      STATS.appDownloads.id,
+    );
+  });
+});
+
+describe("story career copy (owning writer)", () => {
+  const chapters = storyChapters(getRolesSortedByDate());
+  const years = storyYears(calculateTotalExperience());
+  const lines = storyCareerVisitorCopy(chapters, STORY_SECTION, years);
+
+  test("scale captions and scale-bearing headlines are labeled pedigree", () => {
+    expect(chapters.some((ch) => ch.scaleNumber)).toBe(true);
+    expect(unlabeledStoryScale(chapters)).toEqual([]);
+    expect(STORY_SECTION.title.toLowerCase()).not.toMatch(
+      /10m|twenty years|20 years/,
+    );
+    expect(STORY_SECTION.description).toContain(SELF_ATTESTED_HISTORICAL);
+    expect(years.caption).toBe(SELF_ATTESTED_HISTORICAL);
   });
 
-  test("career pedigree stats are self-attested and not live", () => {
-    for (const id of CAREER_PEDIGREE_IDS) {
-      expect(STATS[id].honesty).toBe("self-attested");
-    }
+  test("story career copy never borrows freshness=live", () => {
+    expect(storyCopyBorrowsLiveFreshness(lines)).toEqual([]);
   });
 
-  test("role scale metrics are self-attested historical, never verified-live", () => {
-    let scale = 0;
-    for (const role of ROLES) {
-      for (const metric of role.metrics) {
-        if (typeof metric.value === "number" && metric.value >= 1000) {
-          scale += 1;
-          expect(metric.honesty).toBe("self-attested");
-          expect(metric.verified).not.toBe(true);
-          expect(metric.source).toBe(SELF_ATTESTED_HISTORICAL);
-        }
-      }
-    }
-    expect(scale).toBeGreaterThan(0);
+  test("oracle goes red when story copy borrows freshness=live", () => {
+    expect(
+      storyCopyBorrowsLiveFreshness(["career scale · freshness=live"]),
+    ).toEqual(["career scale · freshness=live"]);
   });
+});
 
-  test("career scale caption never uses live freshness vocabulary", () => {
-    const caption = careerScaleCaption("Downloads");
-    expect(caption).toContain(SELF_ATTESTED_HISTORICAL);
-    expect(caption.toLowerCase()).not.toMatch(/\bfreshness\b/);
-    expect(caption.toLowerCase()).not.toMatch(/\bfreshness=live\b/);
-  });
-
+describe("published visitor bytes", () => {
   test("story headlines that include career scale are labeled pedigree", () => {
     expect(STORY_SCALE_HEADLINES["minimax-ceo"]).toContain("10M");
     expect(STORY_SCALE_HEADLINES["cubeage-founder"]).toContain("10M");
@@ -72,22 +117,7 @@ describe("claim honesty", () => {
     }
   });
 
-  test("personal info has no contact form", () => {
-    expect(Object.hasOwn(PERSONAL_INFO, "contactFormSubjects")).toBe(false);
-  });
-
-  test("site description and short bio do not present 10M+ as a live instrument", () => {
-    const bio = PERSONAL_INFO.shortBio.toLowerCase();
-    const desc = SITE_DESCRIPTION.toLowerCase();
-    expect(bio).not.toContain("10m");
-    expect(desc).not.toContain("10m");
-    expect(bio).toContain("self-attested");
-    expect(desc).toContain("self-attested");
-    expect(bio).not.toContain("freshness=live");
-    expect(desc).not.toContain("freshness=live");
-  });
-
-  test("visitor-visible role copy that names career-scale figures is labeled pedigree", () => {
+  test("rendered role copy that names career-scale figures is labeled pedigree", () => {
     const blobs: string[] = [];
     for (const role of ROLES) {
       blobs.push(role.description);
@@ -102,6 +132,13 @@ describe("claim honesty", () => {
       expect(line).toContain(SELF_ATTESTED_HISTORICAL);
       expect(line.toLowerCase()).not.toContain("freshness=live");
     }
+  });
+
+  test("site description does not present 10M+ as a live instrument", () => {
+    const desc = SITE_DESCRIPTION.toLowerCase();
+    expect(desc).not.toContain("10m");
+    expect(desc).toContain("self-attested");
+    expect(desc).not.toContain("freshness=live");
   });
 
   test("PWA manifest does not present unlabeled career-scale figures", () => {

--- a/src/lib/claim-honesty.ts
+++ b/src/lib/claim-honesty.ts
@@ -1,0 +1,35 @@
+/**
+ * WEB-SITE claim honesty — live instruments vs career pedigree.
+ *
+ * GitHub/npm figures may use freshness=live|stale|unavailable.
+ * Career-scale figures are self-attested historical pedigree and must
+ * never borrow live-instrument vocabulary.
+ */
+
+export type ClaimHonesty = "live-measured" | "self-attested";
+
+export const SELF_ATTESTED_HISTORICAL = "self-attested historical pedigree";
+
+export const LIVE_INSTRUMENT_IDS = [
+  "githubStars",
+  "npmDownloads",
+  "flagshipStars",
+  "flagshipDownloads",
+  "repos",
+] as const;
+
+export const CAREER_PEDIGREE_IDS = [
+  "yearsExperience",
+  "appDownloads",
+  "monthlyPlayers",
+] as const;
+
+export function careerScaleCaption(label: string): string {
+  return `${label} · ${SELF_ATTESTED_HISTORICAL}`;
+}
+
+/** Visitor-visible Story headlines that include career-scale figures. */
+export const STORY_SCALE_HEADLINES = {
+  "minimax-ceo": careerScaleCaption("Facebook games at 10M scale"),
+  "cubeage-founder": careerScaleCaption("25+ games, 10M downloads"),
+} as const;

--- a/src/lib/claim-honesty.ts
+++ b/src/lib/claim-honesty.ts
@@ -10,20 +10,6 @@ export type ClaimHonesty = "live-measured" | "self-attested";
 
 export const SELF_ATTESTED_HISTORICAL = "self-attested historical pedigree";
 
-export const LIVE_INSTRUMENT_IDS = [
-  "githubStars",
-  "npmDownloads",
-  "flagshipStars",
-  "flagshipDownloads",
-  "repos",
-] as const;
-
-export const CAREER_PEDIGREE_IDS = [
-  "yearsExperience",
-  "appDownloads",
-  "monthlyPlayers",
-] as const;
-
 export function careerScaleCaption(label: string): string {
   return `${label} · ${SELF_ATTESTED_HISTORICAL}`;
 }

--- a/src/lib/hero-proof-board.ts
+++ b/src/lib/hero-proof-board.ts
@@ -1,0 +1,99 @@
+/**
+ * Hero proof-board writer — live GitHub/npm cells only.
+ *
+ * Hero must render `heroProofBoard(stats)` and no other proof cells.
+ * Career-scale stats (app downloads / monthly players / years) must not
+ * share this board.
+ */
+import { HERO_PROOF, STATS, type Stat } from "./stats";
+import { compact, type TermStats } from "./terminal";
+
+export type HeroProofKind = "stars" | "downloads" | "flagship";
+
+export interface HeroProofCell {
+  id: string;
+  label: string;
+  display: string;
+  suffix: string;
+  kind: HeroProofKind;
+  hint: string;
+  numeric?: number;
+  wide?: boolean;
+}
+
+/** Career-scale stats dest forbids on the hero proof board. */
+export const CAREER_BOARD_STATS: readonly Stat[] = [
+  STATS.appDownloads,
+  STATS.monthlyPlayers,
+  STATS.yearsExperience,
+];
+
+export function heroProofBoard(stats: TermStats | null): HeroProofCell[] {
+  const stars = stats
+    ? compact(stats.githubStars)
+    : HERO_PROOF.githubStars.display;
+  const downloads = stats
+    ? compact(stats.npmDownloads)
+    : HERO_PROOF.npmDownloads.display;
+  const flagStars = stats
+    ? compact(stats.flagshipStars)
+    : HERO_PROOF.flagshipStars.display;
+  const flagDl = stats
+    ? compact(stats.flagshipDownloads)
+    : HERO_PROOF.flagshipDownloads.display;
+
+  return [
+    {
+      id: HERO_PROOF.githubStars.id,
+      label: "GitHub stars",
+      display: stars,
+      suffix: "★",
+      kind: "stars",
+      hint: "across all repos",
+      numeric: stats?.githubStars,
+    },
+    {
+      id: HERO_PROOF.npmDownloads.id,
+      label: "npm downloads",
+      display: downloads,
+      suffix: "/mo",
+      kind: "downloads",
+      hint: "across packages",
+      numeric: stats?.npmDownloads,
+    },
+    {
+      id: HERO_PROOF.flagshipStars.id,
+      label: "pdf-reader-mcp",
+      display: flagStars,
+      suffix: "★",
+      kind: "flagship",
+      hint: `${flagDl}/mo · the flagship`,
+      numeric: stats?.flagshipStars,
+      wide: true,
+    },
+  ];
+}
+
+/** Cells that would put unlabeled career-scale numbers on the hero board. */
+export function careerScaleOnHeroBoard(
+  cells: HeroProofCell[],
+): HeroProofCell[] {
+  const ids = new Set(CAREER_BOARD_STATS.map((s) => s.id));
+  const labels = new Set(CAREER_BOARD_STATS.map((s) => s.label));
+  const displays = new Set(CAREER_BOARD_STATS.map((s) => s.display));
+  return cells.filter(
+    (cell) =>
+      ids.has(cell.id) || labels.has(cell.label) || displays.has(cell.display),
+  );
+}
+
+/** Rendered-board hits for career display/label (catches extra JSX cells). */
+export function careerScaleInHeroMarkup(html: string): string[] {
+  const hits: string[] = [];
+  for (const stat of CAREER_BOARD_STATS) {
+    if (html.includes(stat.display) || html.includes(stat.label)) {
+      hits.push(stat.id);
+    }
+  }
+  return hits;
+}

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -126,10 +126,3 @@ export const HERO_PROOF = {
   flagshipStars: STATS.flagshipStars,
   flagshipDownloads: STATS.flagshipDownloads,
 } as const;
-
-export const HERO_STATS: Stat[] = [
-  HERO_PROOF.githubStars,
-  HERO_PROOF.npmDownloads,
-  HERO_PROOF.flagshipStars,
-  HERO_PROOF.flagshipDownloads,
-];

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -6,8 +6,13 @@
  * only aggregate fallback the site may ship. Pre-cut values are null until a
  * `public-only/v1` response regenerates them, so unverifiable numbers are never
  * presented as stale or fresh.
+ *
+ * Career-scale figures (years, app downloads, monthly players) are
+ * self-attested historical pedigree. They must not appear on the hero
+ * proof board or use freshness=live vocabulary.
  */
 import baked from "@/data/stats-baked.json";
+import type { ClaimHonesty } from "./claim-honesty";
 
 export interface BakedStats {
   verifiedAt: string | null;
@@ -29,6 +34,7 @@ export interface Stat {
   display: string;
   label: string;
   source: string; // URL or short attestation note
+  honesty: ClaimHonesty;
   verifiedAt?: string | null;
 }
 
@@ -48,6 +54,7 @@ export const STATS: Record<string, Stat> = {
     display: "20+",
     label: "Years building",
     source: "Career since Nakuz (2006)",
+    honesty: "self-attested",
   },
   appDownloads: {
     id: "downloads",
@@ -55,6 +62,7 @@ export const STATS: Record<string, Stat> = {
     display: "10M+",
     label: "App downloads",
     source: "Cubeage — global mobile game installs",
+    honesty: "self-attested",
   },
   monthlyPlayers: {
     id: "players",
@@ -62,6 +70,7 @@ export const STATS: Record<string, Stat> = {
     display: "10M+",
     label: "Monthly players",
     source: "MiniMax / Funimax — peak Facebook MAU",
+    honesty: "self-attested",
   },
   githubStars: {
     id: "stars",
@@ -69,6 +78,7 @@ export const STATS: Record<string, Stat> = {
     display: compact(baked.githubStars),
     label: "GitHub stars",
     source: "Live: SylphxAI + @shtse8 + Cubeage / EpiowAI (non-fork)",
+    honesty: "live-measured",
     verifiedAt: baked.verifiedAt,
   },
   npmDownloads: {
@@ -77,6 +87,7 @@ export const STATS: Record<string, Stat> = {
     display: compact(baked.npmDownloads),
     label: "npm downloads / month",
     source: "@sylphx + @shtse8 packages — npm last-month",
+    honesty: "live-measured",
     verifiedAt: baked.verifiedAt,
   },
   flagshipStars: {
@@ -85,6 +96,7 @@ export const STATS: Record<string, Stat> = {
     display: compact(baked.flagshipStars),
     label: "Stars · pdf-reader-mcp",
     source: "github.com/SylphxAI/pdf-reader-mcp",
+    honesty: "live-measured",
     verifiedAt: baked.verifiedAt,
   },
   flagshipDownloads: {
@@ -93,6 +105,7 @@ export const STATS: Record<string, Stat> = {
     display: compact(baked.flagshipDownloads),
     label: "Downloads / mo · pdf-reader-mcp",
     source: "npmjs.com/package/@sylphx/pdf-reader-mcp — last-month",
+    honesty: "live-measured",
     verifiedAt: baked.verifiedAt,
   },
   repos: {
@@ -101,14 +114,22 @@ export const STATS: Record<string, Stat> = {
     display: compact(baked.repos),
     label: "Public repositories",
     source: "GitHub aggregate across owned orgs",
+    honesty: "live-measured",
     verifiedAt: baked.verifiedAt,
   },
 };
 
-/** Curated 4-stat set for the hero — AI-adoption first, then scale credibility. */
+/** Hero proof-board instruments — live-measured GitHub/npm only. */
+export const HERO_PROOF = {
+  githubStars: STATS.githubStars,
+  npmDownloads: STATS.npmDownloads,
+  flagshipStars: STATS.flagshipStars,
+  flagshipDownloads: STATS.flagshipDownloads,
+} as const;
+
 export const HERO_STATS: Stat[] = [
-  STATS.npmDownloads,
-  STATS.githubStars,
-  STATS.appDownloads,
-  STATS.yearsExperience,
+  HERO_PROOF.githubStars,
+  HERO_PROOF.npmDownloads,
+  HERO_PROOF.flagshipStars,
+  HERO_PROOF.flagshipDownloads,
 ];

--- a/src/lib/story-surface.ts
+++ b/src/lib/story-surface.ts
@@ -1,0 +1,196 @@
+/**
+ * Story surface writer — career-scale figures as labeled pedigree.
+ *
+ * StoryArc must render this module's section copy, chapters, and year
+ * caption. Career copy must never borrow freshness=live.
+ */
+import { formatNumber } from "@/data";
+import type { Role } from "@/data/types";
+import {
+  careerScaleCaption,
+  SELF_ATTESTED_HISTORICAL,
+  STORY_SCALE_HEADLINES,
+} from "./claim-honesty";
+
+export const STORY_SECTION = {
+  index: "01",
+  eyebrow: "The journey",
+  title: "Five eras. One builder.",
+  description:
+    "From a Hong Kong gaming forum in 2006 to AI infrastructure today. Scale figures in this section are self-attested historical pedigree — not live GitHub/npm instruments. Companies are chapters of the same career, not a second product catalog.",
+} as const;
+
+export interface StoryScaleNumber {
+  value: number;
+  label: string;
+  display: string;
+  caption: string;
+}
+
+export interface EraChapter {
+  role: Role;
+  era: string;
+  startYear: string;
+  headline: string;
+  image: string;
+  imageAlt: string;
+  scaleNumber?: StoryScaleNumber;
+  projects?: string[];
+}
+
+function eraProofPoints(role: Role): string[] {
+  const fromAchievements = role.keyAchievements?.slice(0, 5) ?? [];
+  if (fromAchievements.length > 0) return fromAchievements;
+  return (role.responsibilities ?? []).slice(0, 4);
+}
+
+const ERA_META: Record<
+  string,
+  { era: string; headline: string; image: string; imageAlt: string }
+> = {
+  "nakuz-cto": {
+    era: "Web · Community",
+    headline: "Hong Kong's gaming portal",
+    image: "/art/era-web.jpg",
+    imageAlt: "Ambient visual derived from Nakuz brand and portal materials",
+  },
+  "minimax-ceo": {
+    era: "Social Gaming",
+    headline: STORY_SCALE_HEADLINES["minimax-ceo"],
+    image: "/art/era-social.jpg",
+    imageAlt: "Ambient visual derived from MiniMax / Funimax social games",
+  },
+  "cubeage-founder": {
+    era: "Mobile Gaming",
+    headline: STORY_SCALE_HEADLINES["cubeage-founder"],
+    image: "/art/era-mobile.jpg",
+    imageAlt: "Ambient visual derived from Cubeage mobile game products",
+  },
+  "epiow-cto": {
+    era: "Enterprise · Platform",
+    headline: "Organization operating system",
+    // cache-bust: ambient was regenerated from official E-Orbit mark
+    image: "/art/era-consulting.jpg?v=eorbit2",
+    imageAlt:
+      "Ambient visual derived from the official Epiow E-Orbit brand mark",
+  },
+  "sylphx-founder": {
+    era: "AI · Open Source",
+    headline: "The infrastructure AI agents run on",
+    image: "/art/era-ai.jpg",
+    imageAlt:
+      "Ambient visual derived from Sylphx brand mark and AI platform identity",
+  },
+};
+
+export function getScaleNumber(role: Role): StoryScaleNumber | undefined {
+  if (!role.metrics.length) return undefined;
+  const m = role.metrics.reduce((best, cur) => {
+    if (typeof cur.value !== "number") return best;
+    if (!best || typeof best.value !== "number" || cur.value > best.value) {
+      return cur;
+    }
+    return best;
+  });
+  if (typeof m.value !== "number" || m.value < 1000) return undefined;
+  const label =
+    m.label ||
+    m.unit ||
+    (m.type === "downloads"
+      ? "Downloads"
+      : m.type === "users"
+        ? "Users"
+        : "Scale");
+  return {
+    value: m.value,
+    label,
+    display: formatNumber(m.value),
+    caption: careerScaleCaption(label),
+  };
+}
+
+export function storyChapters(roles: Role[]): EraChapter[] {
+  const chapters: EraChapter[] = [];
+  for (const role of roles) {
+    const meta = ERA_META[role.id];
+    if (!meta) continue;
+    const scaleNumber = getScaleNumber(role);
+    chapters.push({
+      role,
+      era: meta.era,
+      startYear: role.period.start.substring(0, 4),
+      headline: meta.headline,
+      image: meta.image,
+      imageAlt: meta.imageAlt,
+      ...(scaleNumber ? { scaleNumber } : {}),
+      projects: eraProofPoints(role),
+    });
+  }
+  return chapters;
+}
+
+export function storyYears(years: number): {
+  display: string;
+  label: string;
+  caption: string;
+} {
+  return {
+    display: `${years}+`,
+    label: "years of building",
+    caption: SELF_ATTESTED_HISTORICAL,
+  };
+}
+
+const LIVE_FRESHNESS = /freshness\s*=\s*live/i;
+
+export function storyCareerVisitorCopy(
+  chapters: EraChapter[],
+  section: typeof STORY_SECTION = STORY_SECTION,
+  years: ReturnType<typeof storyYears> = storyYears(0),
+): string[] {
+  const lines: string[] = [
+    section.title,
+    section.description,
+    years.display,
+    years.label,
+    years.caption,
+  ];
+  for (const ch of chapters) {
+    lines.push(ch.headline, ch.era);
+    if (ch.scaleNumber) {
+      lines.push(
+        ch.scaleNumber.caption,
+        ch.scaleNumber.display,
+        ch.scaleNumber.label,
+      );
+    }
+    lines.push(ch.role.description);
+    lines.push(...(ch.role.keyAchievements ?? []));
+    lines.push(...(ch.role.responsibilities ?? []));
+    lines.push(...(ch.projects ?? []));
+  }
+  return lines;
+}
+
+export function storyCopyBorrowsLiveFreshness(lines: string[]): string[] {
+  return lines.filter((line) => LIVE_FRESHNESS.test(line));
+}
+
+export function unlabeledStoryScale(chapters: EraChapter[]): string[] {
+  const misses: string[] = [];
+  for (const ch of chapters) {
+    if (
+      ch.scaleNumber &&
+      !ch.scaleNumber.caption.includes(SELF_ATTESTED_HISTORICAL)
+    ) {
+      misses.push(`${ch.role.id}:caption`);
+    }
+    if (
+      /10m|\b500k\b|\bmillion\b/i.test(ch.headline) &&
+      !ch.headline.includes(SELF_ATTESTED_HISTORICAL)
+    ) {
+      misses.push(`${ch.role.id}:headline`);
+    }
+  }
+  return misses;
+}


### PR DESCRIPTION
## Identity

- **ID:** WEB-SITE (live)
- **Fate:** live. No new identity. No rename.
- **Writer:** `shtse8/portfolio-website` source (this SHA). Live dest roll of #69/#70/#71 is Apps/Hands and is **not** written here.
- **Dest revision (origin/main `b164718`):**
  - `docs/vision.md` `4beb3f3b3656e26f5228b291610727d42db0d7d9`
  - `docs/capabilities.md` `7567aeceb66b1414c2adc0820bd74f3d5a3097d5`
- **Candidate SHA:** `8e79fc56fcb8cf0daa45d066b2b5e4de93893d55`
- **Layer:** source (visitor-visible copy + hero/story instruments)
- **Harm:** HIGH (public contract). Do not land without independent review of this exact SHA. Head `1adf259` was Rejected (`judge_sha_72`); this SHA is the repair. This SHA was not self-landed.

## Write / effect

Keep dest copy. Repair the source oracle after `judge_sha_72` Reject of `1adf259` (proxy pin claimed as dest oracle).

- Promise (hero): `Hero` maps `heroProofBoard(stats)` through `HeroProofGrid` only. Career-scale downloads/years/players are not on this board.
- Story: `StoryArc` renders `story-surface` section copy, chapters, and year caption. Nakuz → MiniMax → Cubeage → Epiow → Sylphx. Career-scale figures labeled `self-attested historical pedigree` and never `freshness=live`. Story H2 is `Five eras. One builder.` (years remain labeled in the section lead and footer).
- Site/PWA description still do not present 10M+/20 years as live proof.
- `docs/vision.md` / `docs/capabilities.md` unchanged. No TypeScript backend, Docker, or listing change.

## Oracle

Source (this SHA) — owning-writer postcondition, not unused-array / honesty-field pins:

- `heroProofBoard(stats)` cells + rendered `HeroProofGrid` markup contain no career-scale id/label/display (`STATS.appDownloads` / `monthlyPlayers` / `yearsExperience`). Goes red if those numbers share the board.
- `storyChapters` visitor copy: scale captions and scale-bearing headlines labeled pedigree; `storyCopyBorrowsLiveFreshness` is empty. Goes red if Story career copy borrows `freshness=live`.
- Published-byte goldens: `SITE_DESCRIPTION`, `manifest.json`, `STORY_SCALE_HEADLINES`, rendered role description/achievements.
- Deleted pins: unused `HERO_STATS`, `STATS[id].honesty`, `metric.honesty` / `verified` / `source`, `contactFormSubjects`, unused `shortBio`.
- `bun run check` — biome + `tsc --noEmit` + bun test → 59 pass, 0 fail
- `bun run build` — static routes `/`, `/story`, `/work`, `/contact` (no `/archive`)
- `bun scripts/check-cinematic-markers.mjs` — PASSED

Live occupancy at `https://kylet.se` is not this SHA's oracle (deploy layer is `blocked_by` Apps/Hands). Career figures must never use `freshness=live`.

## Recovery

- If this contract is wrong: revert this SHA; hero again presents 10M+/years beside GitHub/npm, and Story/role copy presents unlabeled career scale.
- Live dest after land still needs Apps/Hands to roll the site image. This SHA does not deploy.

## Floors

```
Outcome: WEB-SITE source copy distinguishes live GitHub/npm instruments from labeled self-attested career pedigree
Applicable clause: standards/work.md High-harm surfaces (public contracts); PRINCIPLES.md Correctness; proof.md Postcondition, not proxy; ADR-009 Ready candidate_sha is not Done
Trigger: dest #71 four-surface honesty (hero live-only; Story career labeled; never freshness=live on career)
Product mapping: src/components/Hero.tsx, src/components/HeroProofGrid.tsx, src/components/StoryArc.tsx, src/lib/hero-proof-board.ts, src/lib/story-surface.ts, src/lib/stats.ts, src/lib/claim-honesty.ts, src/data/{roles,personal,organizations,types}.ts, src/app/layout.tsx, public/manifest.json
Oracle: owning-writer postcondition (heroProofBoard + rendered HeroProofGrid; storyChapters visitor copy); bun run check 59 pass; static export routes / /story /work /contact; cinematic markers pass
Gap: live dest occupancy owned by Apps/Hands deploy; WEB-CHAT gateway credential is a different identity; WEB-STATS public-only attestations are a different identity
```

## Out of set

- Landed #69 dual-catalog browsing retire, #70 overlay catalog cut, #71 dest-lock (do not re-land)
- Rejected head `1adf259` (do not land)
- Live dest / Apps+Hands occupancy of `b164718` / `409062b`
- WEB-CHAT Apps gateway secret (`sk-sx-`)
- WEB-STATS `repositoryVisibility` / `projectionRevision` live attestations
- Renovate / Dependabot
- Dest-doc rewrite (`docs/vision.md` / `docs/capabilities.md` unchanged)
- Self-land / self-review