### PR TITLE
docs: peel ADR numbers out of README and PROJECT entry

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -13,7 +13,7 @@ terminal data, and the on-site AI agent (Sylphx AI Gateway).
 ## Goals
 
 - Ship fast, static portfolio UX from `src/` → `out/` (no server runtime in the web image).
-- Run all live API authority in Rust with a **single JSON REST contract** (ADR-169).
+- Run all live API authority in Rust with a **single JSON REST contract** (`api-rust/src/contract.rs`).
 - Chat calls the Sylphx AI Gateway Responses wire with server-side credentials only.
 
 ## Non-Goals

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Kyle Tse's personal proof surface: a static portfolio with a small Rust live API
 **Must not** set `AI_GATEWAY_BASE_URL` to Platform management (`api.sylphx.com`)
 or `AI_GATEWAY_KEY` to a Platform product secret (`sk_prod_*`), leftover
 internal `ck_*`, or any non-`sk-sx-*` bearer — those are rejected by
-`resolve_ai()` so `GET /chat/ready` stays fail-closed (ADR-169 honesty).
+`resolve_ai()` so `GET /chat/ready` stays fail-closed.
 
 `SYLPHX_URL` is **never** used as a server credential. Without a valid gateway
 credential the API fails closed (`503 chat is warming up`). UI probes


### PR DESCRIPTION
ADR-pollution peel per owner law (SylphxAI/owner#324): entry files cite decisions only through the single Decisions: docs/adr/ line. Contract pointer replaces the bare ADR number. No dest, contract, or source change.